### PR TITLE
GAP-2216/remove logs, and fix parseFileName method

### DIFF
--- a/src/main/java/gov/cabinetoffice/gap/service/ZipService.java
+++ b/src/main/java/gov/cabinetoffice/gap/service/ZipService.java
@@ -32,7 +32,8 @@ public class ZipService {
 
     private static final String SUBMISSION_ATTACHMENTS_BUCKET_NAME = System
             .getenv("SUBMISSION_ATTACHMENTS_BUCKET_NAME");
-
+    //regex for any special character that are not allowed in window os : <, >, ", /, \, |, ?, or *
+    private static final String SPECIAL_CHARACTER_REGEX = "[<>\"\\/|?*\\\\]";
     private static AmazonS3 s3Client;
 
     public static void createZip(final AmazonS3 client, final String filename, final String applicationId,
@@ -172,6 +173,6 @@ public class ZipService {
         final String applicationIdAndSubmissionId = applicationId + "/" + submissionId + "/";
         final String filenameWithoutApplicationIdAndSubmissionId = objectKey.replace(applicationIdAndSubmissionId, "");
         final String folderNameToRemove = filenameWithoutApplicationIdAndSubmissionId.split("/")[0];
-        return filenameWithoutApplicationIdAndSubmissionId.replace(folderNameToRemove + "/", "");
+        return filenameWithoutApplicationIdAndSubmissionId.replace(folderNameToRemove + "/", "").replaceAll(SPECIAL_CHARACTER_REGEX, "_");
     }
 }

--- a/src/test/java/gov/cabinetoffice/gap/service/ZipServiceTest.java
+++ b/src/test/java/gov/cabinetoffice/gap/service/ZipServiceTest.java
@@ -120,15 +120,37 @@ public class ZipServiceTest {
     }
 
     @Test
-    void shouldReturnLastPartOfSubStringWhenFileNameIsParsed() {
+    void shouldHandleMultiplePeriodsInFilename() {
+        String result = ZipService.parseFileName("330/submission/folder/file.odt.w..pdf", 1, "330","submission");
 
-        String result = ZipService.parseFileName("s3://gap-attachments" +
-                "/13" +
-                "/035f31f6-2877-4f87-8a9b-32649a527668" +
-                "/9d4a3ed6-5a26-4d02-be49-bab13c11a2bf" +
-                "/test File Name.odt", 1);
+        assertEquals("file.odt.w._1.pdf", result);
+    }
+    @Test
+    void shouldHandleFileNameThatAreNotInTheRegex() {
+        String result = ZipService.parseFileName("330/submission/folder/file.word", 1, "330","submission");
 
-        assertEquals("test File Name_1.odt", result);
+        assertEquals("file_1.word", result);
+    }
+
+    @Test
+    void shouldHandleFileNameThatAreNotInTheRegexWithMoreDots() {
+        String result = ZipService.parseFileName("330/submission/folder/file.a.b.c.d.word", 1, "330","submission");
+
+        assertEquals("file.a.b.c.d_1.word", result);
+    }
+
+    @Test
+    void shouldReturnFileNameWithSuffix() {
+        String result = ZipService.parseFileName("330/submission/folder/file.pdf", 1, "330","submission");
+
+        assertEquals("file_1.pdf", result);
+    }
+
+    @Test
+    void shouldReturnFileNameWithSuffixWhenFileNameHasLoadsOfSpecialCharacter() {
+        String result = ZipService.parseFileName("330/submission/folder//test... /File {{{}}} Name.???FLL. odt.&*%*$odt.xls", 1, "330","submission");
+
+        assertEquals("/test... /File {{{}}} Name.???FLL. odt.&*%*$odt_1.xls", result);
     }
 
     private File unzipFile(final ZipInputStream zis, final String filePath) throws Exception {

--- a/src/test/java/gov/cabinetoffice/gap/service/ZipServiceTest.java
+++ b/src/test/java/gov/cabinetoffice/gap/service/ZipServiceTest.java
@@ -148,9 +148,9 @@ public class ZipServiceTest {
 
     @Test
     void shouldReturnFileNameWithSuffixWhenFileNameHasLoadsOfSpecialCharacter() {
-        String result = ZipService.parseFileName("330/submission/folder//test... /File {{{}}} Name.???FLL. odt.&*%*$"+ "odt.xls", 1, "330","submission");
+        String result = ZipService.parseFileName("330/submission/folder//test... /File {{{}}} Name.???FLL. odt.<>\"/\\|?*"+ "odt.xls", 1, "330","submission");
 
-        assertEquals("/test... /File {{{}}} Name.???FLL. odt.&*%*$odt_1.xls", result);
+        assertEquals("_test... _File {{{}}} Name.___FLL. odt.________odt_1.xls", result);
     }
 
     private File unzipFile(final ZipInputStream zis, final String filePath) throws Exception {

--- a/src/test/java/gov/cabinetoffice/gap/service/ZipServiceTest.java
+++ b/src/test/java/gov/cabinetoffice/gap/service/ZipServiceTest.java
@@ -148,7 +148,7 @@ public class ZipServiceTest {
 
     @Test
     void shouldReturnFileNameWithSuffixWhenFileNameHasLoadsOfSpecialCharacter() {
-        String result = ZipService.parseFileName("330/submission/folder//test... /File {{{}}} Name.???FLL. odt.&*%*$odt.xls", 1, "330","submission");
+        String result = ZipService.parseFileName("330/submission/folder//test... /File {{{}}} Name.???FLL. odt.&*%*$"+ "odt.xls", 1, "330","submission");
 
         assertEquals("/test... /File {{{}}} Name.???FLL. odt.&*%*$odt_1.xls", result);
     }


### PR DESCRIPTION
fix the parseFileName method. 
we would need to fix the validation on the applicant frontend, for when we upload files.
if a file uploaded contains a \ it will be cut.
eg test\file.pdf will be saved in s3bucket and json blob as file.pdf