### PR TITLE
Gap 2215 file names too long

### DIFF
--- a/src/main/java/gov/cabinetoffice/gap/service/ZipService.java
+++ b/src/main/java/gov/cabinetoffice/gap/service/ZipService.java
@@ -34,6 +34,8 @@ public class ZipService {
             .getenv("SUBMISSION_ATTACHMENTS_BUCKET_NAME");
     //regex for any special character that are not allowed in window os : <, >, ", /, \, |, ?, or *
     private static final String SPECIAL_CHARACTER_REGEX = "[<>\"\\/|?*\\\\]";
+
+    public static final Integer LONG_FILE_NAME_LENGTH = 50; //50 characters may be too strict but can revisit if required
     private static AmazonS3 s3Client;
 
     public static void createZip(final AmazonS3 client, final String filename, final String applicationId,
@@ -111,7 +113,11 @@ public class ZipService {
         final String fileExtension = "." + fileNameParts[fileNameParts.length - 1];
         final String filenameWithoutExtension = filenameWithoutFolderName.replace(fileExtension, "");
 
-        return filenameWithoutExtension.concat("_" + suffix + fileExtension);
+        // Need to trim very long file names to prevent max path length errors in windows
+        final String truncatedFileName = filenameWithoutExtension.length() > LONG_FILE_NAME_LENGTH ?
+                filenameWithoutExtension.substring(0, LONG_FILE_NAME_LENGTH).trim() : filenameWithoutExtension;
+
+        return truncatedFileName.concat("_" + suffix + fileExtension);
     }
 
 

--- a/src/main/java/gov/cabinetoffice/gap/utils/HelperUtils.java
+++ b/src/main/java/gov/cabinetoffice/gap/utils/HelperUtils.java
@@ -2,20 +2,28 @@ package gov.cabinetoffice.gap.utils;
 
 public class HelperUtils {
 
+    private HelperUtils() {
+        throw new IllegalStateException("Utility class");
+    }
+
     private static final String DOMAIN = System.getenv("REDIRECT_DOMAIN");
 
     public static String getRedirectUrl(String schemeId, String batchId) {
         return DOMAIN + "/scheme/" + schemeId + "/" + batchId;
     }
 
-    public static String generateFilename(String legalName, String gapId) {
-        if(legalName == null || gapId == null) {
+    public static String generateFilename(final String legalName, final String gapId) {
+
+        if (legalName == null || gapId == null) {
             throw new RuntimeException("legalName and gapId cannot be null");
         }
 
-        String cleanLegalName = legalName.replace(" ", "_")
-                .replace("/", "_");
-        String cleanGapId = gapId.replace("-", "_");
+        final String truncatedLegalName = legalName.length() > 50 ? legalName.substring(0, 50).trim() : legalName;
+        final String cleanLegalName = truncatedLegalName
+                .replace(" ", "_")
+                .replaceAll("[<>:\"/\\\\?*]", "_");
+
+        final String cleanGapId = gapId.replace("-", "_");
         return String.format("%s_%s", cleanLegalName, cleanGapId);
     }
 

--- a/src/test/java/gov/cabinetoffice/gap/service/ZipServiceTest.java
+++ b/src/test/java/gov/cabinetoffice/gap/service/ZipServiceTest.java
@@ -153,6 +153,17 @@ public class ZipServiceTest {
         assertEquals("_test... _File {{{}}} Name.___FLL. odt.________odt_1.xls", result);
     }
 
+    @Test
+    void shouldTruncateLongFileNames() {
+        final String folder = "330/submission/folder/";
+        final String longFileName = "202303 [DRAFT] - Open Networks Ecosystem competition - Grant Funding Agreement.docx-EmbeddedFile.xlsx";
+        final String truncatedLongFileName = longFileName.substring(0, ZipService.LONG_FILE_NAME_LENGTH).trim();
+
+        final String result = ZipService.parseFileName(folder + longFileName, 1, "330","submission");
+
+        assertEquals(truncatedLongFileName + "_1.xlsx", result);
+    }
+
     private File unzipFile(final ZipInputStream zis, final String filePath) throws Exception {
         final byte[] buffer = new byte[1024];
         final File unzippedFile = new File(filePath);

--- a/src/test/java/gov/cabinetoffice/gap/utils/HelperUtilsTest.java
+++ b/src/test/java/gov/cabinetoffice/gap/utils/HelperUtilsTest.java
@@ -36,6 +36,25 @@ public class HelperUtilsTest {
         }
 
         @Test
+        void specialCharactersAreReplaced() {
+            String generatedFilename = HelperUtils.generateFilename("Org<with>lots/of\\special*characters?in_its name", "GAP-GAP-20221019");
+
+            assertThat(generatedFilename).isEqualTo("Org_with_lots_of_special_characters_in_its_name_GAP_GAP_20221019");
+        }
+
+        @Test
+        void legalNamesLongerThan50CharsAreTrimmed() {
+            final String longLegalName = "a legal name with more than fifty characters that needs to be trimmed by the document export lambda so that file name length limits in windows don't cause problems";
+            final String trimmedLegalName = longLegalName.substring(0, 50)
+                    .trim()
+                    .replace(" ", "_");
+
+            String generatedFilename = HelperUtils.generateFilename(longLegalName, "GAP-GAP-20221019");
+
+            assertThat(generatedFilename).isEqualTo(trimmedLegalName + "_GAP_GAP_20221019");
+        }
+
+        @Test
         void nullLegalNameGenerateFilename() {
 
             assertThatThrownBy(() -> HelperUtils.generateFilename(null, "GAP-GAP-20221019"))


### PR DESCRIPTION
- truncating long file names to prevent issues with opening on windows
- truncating long organisation names to prevent issues with creating file paths that are too long to be valid
- replacing special characters in organisation names with _ to prevent issues with opening the folders in windows