### PR TITLE
TMI2-572: Optional values exporting as null

### DIFF
--- a/src/main/java/gov/cabinetoffice/gap/service/OdtService.java
+++ b/src/main/java/gov/cabinetoffice/gap/service/OdtService.java
@@ -163,6 +163,17 @@ public class OdtService {
                                     responseParagraph.addContentWhitespace("\n");
                                 }
                                 break;
+                            case YesNo:
+                            case Dropdown:
+                            case ShortAnswer:
+                            case LongAnswer:
+                            case Numeric:
+                                if(question.getResponse() == null) {
+                                    responseParagraph.addContentWhitespace("Not provided");
+                                } else {
+                                    responseParagraph.addContentWhitespace(question.getResponse() + "\n");
+                                }
+                                break;
                             default:
                                 responseParagraph.addContentWhitespace(question.getResponse() + "\n");
                                 break;


### PR DESCRIPTION
TMI2-572: https://technologyprogramme.atlassian.net/browse/TMI2-572

If optional questions have no response then we need to say "Not provided" instead of just having null