### PR TITLE
TMI2-591: checks if date response is empty

### DIFF
--- a/src/main/java/gov/cabinetoffice/gap/service/OdtService.java
+++ b/src/main/java/gov/cabinetoffice/gap/service/OdtService.java
@@ -157,10 +157,10 @@ public class OdtService {
                                 break;
                             case Date:
                                 if (question.getMultiResponse() != null) {
-                                    responseParagraph.addContentWhitespace(String.join("-",
-                                            question.getMultiResponse()) + "\n");
+                                    final String date = String.join("-", question.getMultiResponse());
+                                    responseParagraph.addContentWhitespace((date.equals("--") ? "Not provided" : date) + "\n");
                                 } else {
-                                    responseParagraph.addContentWhitespace("\n");
+                                    responseParagraph.addContentWhitespace("Not provided");
                                 }
                                 break;
                             case YesNo:


### PR DESCRIPTION
TMI2-591: https://technologyprogramme.atlassian.net/browse/TMI2-591

If a date is optional and the user doesn't enter a date, the mutliresponse returns an string array which we check if it's empty then return "Not provided" as the response.
