### PR TITLE
GAP:2398 New ODT Structure for Admins

### DIFF
--- a/.github/workflows/feature.yml
+++ b/.github/workflows/feature.yml
@@ -22,10 +22,10 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
-      - name: Set up JDK 11
+      - name: Set up JDK 17
         uses: actions/setup-java@v3
         with:
-          java-version: "11"
+          java-version: "17"
           distribution: "corretto"
           cache: maven
       - name: Build with Maven

--- a/.github/workflows/pushImage.yml
+++ b/.github/workflows/pushImage.yml
@@ -22,10 +22,10 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
-      - name: Set up JDK 11
+      - name: Set up JDK 17
         uses: actions/setup-java@v3
         with:
-          java-version: "11"
+          java-version: "17"
           distribution: "corretto"
           cache: maven
       - name: Build with Maven
@@ -64,10 +64,10 @@ jobs:
           # Fetch all commits since we use the total commit count to determine the build version
           fetch-depth: 0
 
-      - name: Set up JDK 11
+      - name: Set up JDK 17
         uses: actions/setup-java@v3
         with:
-          java-version: "11"
+          java-version: "17"
           distribution: "corretto"
           cache: maven
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM public.ecr.aws/lambda/java:11
+FROM public.ecr.aws/lambda/java:17
 
 # Copy function code and runtime dependencies from Maven layout
 COPY target/classes ${LAMBDA_TASK_ROOT}

--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
     <name>gap-lambda-submission-export</name>
     <description>A lambda for exporting submissions to S3</description>
     <properties>
-        <java.version>11</java.version>
+        <java.version>17</java.version>
     </properties>
     <dependencies>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -159,8 +159,8 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.8.1</version>
                 <configuration>
-                    <source>11</source>
-                    <target>11</target>
+                    <source>17</source>
+                    <target>17</target>
                     <annotationProcessorPaths>
                         <path>
                             <groupId>org.projectlombok</groupId>

--- a/src/main/java/gov/cabinetoffice/gap/service/OdtService.java
+++ b/src/main/java/gov/cabinetoffice/gap/service/OdtService.java
@@ -39,7 +39,7 @@ public class OdtService {
     private static final String APPLICANT_ORG_CHARITY_NUMBER = "APPLICANT_ORG_CHARITY_NUMBER";
     private static final String APPLICANT_ORG_COMPANIES_HOUSE = "APPLICANT_ORG_COMPANIES_HOUSE";
     private static final String APPLICANT_AMOUNT = "APPLICANT_AMOUNT";
-    private static final String BENEFITIARY_LOCATION = "BENEFITIARY_LOCATION";
+    private static final String BENEFICIARY_LOCATION = "BENEFICIARY_LOCATION";
     private static final String APPLICANT_ORG_TYPE_INDIVIDUAL = "I am applying as an individual";
     private static final String Heading_20_1 = "Heading_20_1";
     private static final String Heading_20_2 = "Heading_20_2";
@@ -52,150 +52,6 @@ public class OdtService {
     }
 
     public static void generateSingleOdt(final Submission submission, final String filename) throws Exception {
-//        try {
-//            Integer schemeVersion = submission.getSchemeVersion();
-//            OdfTextDocument odt = OdfTextDocument.newTextDocument();
-//            OdfContentDom contentDom = odt.getContentDom();
-//            OfficeTextElement documentText = odt.getContentRoot();
-//            String largeHeadingStyle = "Heading_20_2";
-//            String smallHeadingStyle = "Heading_20_10";
-//            DateTimeFormatter dateTimeFormatter = DateTimeFormatter.ofPattern("dd/MM/yyyy").withZone(ZoneId.of("GMT"));
-//            final String fundingSectionName = schemeVersion == 1 ? ESSENTIAL_SECTION_ID : FUNDING_DETAILS_SECTION_ID;
-//            final String requiredCheckSectionName = schemeVersion == 1 ? ESSENTIAL_SECTION_ID : ORGANISATION_DETAILS_SECTION_ID;
-//
-//            final SubmissionSection eligibilitySection = submission.getSectionById(ELIGIBILITY_SECTION_ID);
-//            final SubmissionSection requiredCheckSection = submission.getSectionById(requiredCheckSectionName);
-//            final String orgType = requiredCheckSection.getQuestionById(APPLICANT_TYPE).getResponse();
-//            final Boolean isIndividual = Objects.equals(orgType, APPLICANT_ORG_TYPE_INDIVIDUAL);
-//
-//            OdfTextParagraph sectionBreak = new OdfTextParagraph(contentDom);
-//            sectionBreak.addContentWhitespace("\n\n");
-//
-//            // Add top-level submission info
-//            OdfTextHeading mainHeading = new OdfTextHeading(contentDom);
-//            mainHeading.addStyledContentWhitespace(smallHeadingStyle, "Scheme applied for: " +
-//                    submission.getSchemeName() + "\n\n");
-//            final String nameHeadingPrefix = isIndividual ? "Applicant" : "Organisation";
-//            mainHeading.addStyledContentWhitespace(smallHeadingStyle, nameHeadingPrefix + " name: " +
-//                    submission.getLegalName() + "\n\n");
-//            mainHeading.addStyledContentWhitespace(smallHeadingStyle, "Gap ID: " +
-//                    submission.getGapId() + "\n\n");
-//            mainHeading.addStyledContentWhitespace(smallHeadingStyle, "Submitted date: " +
-//                    dateTimeFormatter.format(submission.getSubmittedDate()) + "\n\n");
-//            mainHeading.addStyledContentWhitespace(smallHeadingStyle, "Amount applied for: £" +
-//                    submission.getQuestionById(fundingSectionName, APPLICANT_AMOUNT).getResponse());
-//            documentText.appendChild(mainHeading);
-//
-//            // ELIGIBILITY SECTION
-//            OdfTextHeading eligibilityHeading = new OdfTextHeading(contentDom);
-//            OdfTextParagraph eligibilityStatement = new OdfTextParagraph(contentDom);
-//            OdfTextParagraph eligibilityResponse = new OdfTextParagraph(contentDom);
-//
-//            documentText.appendChild(sectionBreak.cloneElement());
-//            eligibilityHeading.addStyledContent(largeHeadingStyle, "Section 1 - " +
-//                    eligibilitySection.getSectionTitle());
-//            documentText.appendChild(eligibilityHeading);
-//            eligibilityStatement.addStyledContentWhitespace(smallHeadingStyle, "Eligibility statement: \n" +
-//                    eligibilitySection.getQuestionById(ELIGIBILITY_SECTION_ID).getDisplayText());
-//            eligibilityResponse.addContentWhitespace("Applicant selected: \n" +
-//                    eligibilitySection.getQuestionById(ELIGIBILITY_SECTION_ID).getResponse());
-//            documentText.appendChild(eligibilityStatement);
-//            documentText.appendChild(eligibilityResponse);
-//
-//            // ESSENTIAL SECTION or ORGANISATION_DETAILS/FUNDING_DETAILS SECTION based on scheme version
-//
-//            OdfTextHeading requiredCheckHeading = new OdfTextHeading(contentDom);
-//            OdfTextParagraph locationQuestion = new OdfTextParagraph(contentDom);
-//            OdfTextParagraph locationResponse = new OdfTextParagraph(contentDom);
-//
-//            documentText.appendChild(sectionBreak.cloneElement());
-//            requiredCheckHeading.addStyledContent(largeHeadingStyle, "Section 2 - " +
-//                    "Required checks");
-//            documentText.appendChild(requiredCheckHeading);
-//            documentText.appendChild(new OdfTextParagraph(contentDom).addContentWhitespace(""));
-//
-//            documentText.appendChild(generateEssentialTable(documentText, requiredCheckSection, submission.getEmail()));
-//
-//            locationQuestion.addStyledContent(smallHeadingStyle, "Where this funding will be spent");
-//
-//            locationResponse.addContentWhitespace(String.join(",\n",
-//                    submission.getQuestionById(fundingSectionName, BENEFITIARY_LOCATION).getMultiResponse()));
-//
-//            documentText.appendChild(locationQuestion);
-//            documentText.appendChild(locationResponse);
-//
-//
-//            // CUSTOM SECTIONS
-//            AtomicInteger count = new AtomicInteger(3); // custom section starts from 3
-//            submission.getSections().forEach(section -> {
-//                // ignore eligibility and essential section
-//                if (!Objects.equals(section.getSectionId(), ELIGIBILITY_SECTION_ID) &&
-//                        !Objects.equals(section.getSectionId(), ESSENTIAL_SECTION_ID) &&
-//                        !Objects.equals(section.getSectionId(), ORGANISATION_DETAILS_SECTION_ID) &&
-//                        !Objects.equals(section.getSectionId(), FUNDING_DETAILS_SECTION_ID)) {
-//
-//                    documentText.appendChild(sectionBreak.cloneElement());
-//
-//                    // Add section title
-//                    OdfTextHeading sectionHeading = new OdfTextHeading(contentDom);
-//                    sectionHeading.addStyledContent(largeHeadingStyle, "Section " + count + " - " +
-//                            section.getSectionTitle());
-//                    documentText.appendChild(sectionHeading);
-//
-//                    // Add the questions
-//                    section.getQuestions().forEach(question -> {
-//                        OdfTextParagraph questionParagraph = new OdfTextParagraph(contentDom);
-//                        OdfTextParagraph responseParagraph = new OdfTextParagraph(contentDom);
-//                        questionParagraph.addStyledContent(smallHeadingStyle, question.getFieldTitle());
-//
-//                        switch (question.getResponseType()) {
-//                            case AddressInput:
-//                            case MultipleSelection:
-//                                if (question.getMultiResponse() != null) {
-//                                    responseParagraph.addContentWhitespace(String.join(",\n",
-//                                            question.getMultiResponse()) + "\n");
-//                                } else {
-//                                    responseParagraph.addContentWhitespace("\n");
-//                                }
-//                                break;
-//                            case SingleFileUpload:
-//                                if (question.getResponse() != null) {
-//                                    int index = question.getResponse().lastIndexOf(".");
-//
-//                                    responseParagraph.addContentWhitespace("File name: " + question.getResponse().substring(0, index) + "\n");
-//                                    responseParagraph.addContentWhitespace("File extension: " + question.getResponse().substring(index + 1) + "\n");
-//                                } else {
-//                                    responseParagraph.addContentWhitespace("\n");
-//                                }
-//                                break;
-//                            case Date:
-//                                if (question.getMultiResponse() != null) {
-//                                    responseParagraph.addContentWhitespace(String.join("-",
-//                                            question.getMultiResponse()) + "\n");
-//                                } else {
-//                                    responseParagraph.addContentWhitespace("\n");
-//                                }
-//                                break;
-//                            default:
-//                                responseParagraph.addContentWhitespace(question.getResponse() + "\n");
-//                                break;
-//                        }
-//
-//                        documentText.appendChild(questionParagraph);
-//                        documentText.appendChild(responseParagraph);
-//                    });
-//
-//                    count.getAndIncrement();
-//                }
-//            });
-//
-//            odt.save(String.format("/tmp/%s.odt", filename));
-//            odt.close();
-//        } catch (Exception e) {
-//            logger.error("Could not generate ODT for given submission", e);
-//            throw e;
-//        }
-//        logger.info("ODT file generated successfully");
             try {
                 OdfStyleProcessor styleProcessor = new OdfStyleProcessor();
                 int schemeVersion = submission.getSchemeVersion();
@@ -250,87 +106,6 @@ public class OdtService {
         }
         logger.info("ODT file generated successfully");
     }
-
-    /**
-     * Wouldn't you know it, there's no good docs on generating a table by hand using ODFDOM.
-     * There might be a better way to do it, but it sure isn't documented anywhere.
-     */
-//    private static TableTableElement generateEssentialTable(final OfficeTextElement documentText,
-//                                                            final SubmissionSection section,
-//                                                            final String email) {
-//        OdfTable odfTable = OdfTable.newTable(documentText, 7, 2);
-//
-//        final String orgType = section.getQuestionById(APPLICANT_TYPE).getResponse();
-//        final Boolean isIndividual = Objects.equals(orgType, APPLICANT_ORG_TYPE_INDIVIDUAL);
-//
-//        final String orgNameHeading = isIndividual ? "Applicant name" : "Legal name of organisation";
-//        odfTable.getRowByIndex(0).getCellByIndex(0).setStringValue(orgNameHeading);
-//        odfTable.getRowByIndex(0).getCellByIndex(1).setStringValue(section.getQuestionById(APPLICANT_ORG_NAME).getResponse());
-//
-//        odfTable.getRowByIndex(1).getCellByIndex(0).setStringValue("Type of organisation");
-//        odfTable.getRowByIndex(1).getCellByIndex(1).setStringValue(orgType);
-//
-//        String[] applicantOrgAddress = section.getQuestionById(APPLICANT_ORG_ADDRESS).getMultiResponse();
-//
-//        odfTable.getRowByIndex(2).getCellByIndex(0).setStringValue("The first line of address for the organisation");
-//        odfTable.getRowByIndex(2).getCellByIndex(1).setStringValue(applicantOrgAddress[0]);
-//
-//        odfTable.getRowByIndex(3).getCellByIndex(0).setStringValue("The second line of address for the organisation");
-//        odfTable.getRowByIndex(3).getCellByIndex(1).setStringValue(applicantOrgAddress[1]);
-//
-//        odfTable.getRowByIndex(4).getCellByIndex(0).setStringValue("The town of the address for the organisation");
-//        odfTable.getRowByIndex(4).getCellByIndex(1).setStringValue(applicantOrgAddress[2]);
-//
-//        odfTable.getRowByIndex(5).getCellByIndex(0).setStringValue("The county of the address for the organisation");
-//        odfTable.getRowByIndex(5).getCellByIndex(1).setStringValue(applicantOrgAddress[3]);
-//
-//        odfTable.getRowByIndex(6).getCellByIndex(0)
-//                .setStringValue("The postcode of the address for the organisation");
-//        odfTable.getRowByIndex(6).getCellByIndex(1)
-//                .setStringValue(applicantOrgAddress[4]);
-//
-//        odfTable.getRowByIndex(7).getCellByIndex(0)
-//                .setStringValue("The email address for the lead applicant");
-//        odfTable.getRowByIndex(7).getCellByIndex(1)
-//                .setStringValue(email);
-//
-//        Integer index = 8;
-//        final Boolean hasCharityCommissionNumber = section
-//                .mayGetQuestionById(APPLICANT_ORG_CHARITY_NUMBER)
-//                .isPresent();
-//        if (hasCharityCommissionNumber) {
-//            odfTable.getRowByIndex(index)
-//                    .getCellByIndex(0)
-//                    .setStringValue("Charities Commission number if the organisation has one (if blank, number has not been entered)");
-//            odfTable.getRowByIndex(index)
-//                    .getCellByIndex(1)
-//                    .setStringValue(section
-//                            .mayGetQuestionById(APPLICANT_ORG_CHARITY_NUMBER)
-//                            .map(SubmissionQuestion::getResponse)
-//                            .orElse("")
-//                    );
-//            index++;
-//        }
-//
-//        final Boolean hasCompaniesHouseNumber = section
-//                .mayGetQuestionById(APPLICANT_ORG_COMPANIES_HOUSE)
-//                .isPresent();
-//        if (hasCompaniesHouseNumber) {
-//            odfTable.getRowByIndex(index)
-//                    .getCellByIndex(0)
-//                    .setStringValue("Companies House number if the organisation has one (if blank, number has not been entered)");
-//            odfTable.getRowByIndex(index)
-//                    .getCellByIndex(1)
-//                    .setStringValue(section
-//                            .mayGetQuestionById(APPLICANT_ORG_COMPANIES_HOUSE)
-//                            .map(SubmissionQuestion::getResponse)
-//                            .orElse("")
-//                    );
-//        }
-//
-//        return odfTable.getOdfElement();
-//    }
-//}
 
     private static void addPageBreak(OdfContentDom contentDocument, OdfTextDocument doc) throws Exception {
         final OdfOfficeAutomaticStyles styles = contentDocument.getAutomaticStyles();
@@ -413,7 +188,7 @@ public class OdtService {
         table.getRowByIndex(0).getCellByIndex(1).setStringValue("£" + submission.getQuestionById(fundingSectionName, APPLICANT_AMOUNT).getResponse());
         table.getRowByIndex(1).getCellByIndex(0).setStringValue("Where funding will be spent");
         table.getRowByIndex(1).getCellByIndex(1).setStringValue(String.join(",\n",
-                submission.getQuestionById(fundingSectionName, BENEFITIARY_LOCATION).getMultiResponse()));
+                submission.getQuestionById(fundingSectionName, BENEFICIARY_LOCATION).getMultiResponse()));
 
         documentText.appendChild(locationQuestion);
         documentText.appendChild(table.getOdfElement());
@@ -465,7 +240,7 @@ public class OdtService {
         });
         documentText.appendChild(new OdfTextParagraph(contentDom).addContentWhitespace(""));
         count.getAndIncrement();
-    };
+    }
 
     private static void populateDocumentFromQuestionResponse(SubmissionQuestion question,
                                                              OfficeTextElement documentText,
@@ -600,7 +375,7 @@ public class OdtService {
 
         styleProcessor.setStyle(stylesOfficeStyles.getDefaultStyle(OdfStyleFamily.Paragraph))
                 .margins("0cm", "0cm", "0cm", "0cm")
-                .fontFamilly("Arial")
+                .fontFamily("Arial")
                 .fontSize("11pt")
                 .textAlign("normal");
 
@@ -629,19 +404,19 @@ public class OdtService {
         //test
         styleProcessor.setStyle(stylesOfficeStyles.newStyle(Text_20_1, OdfStyleFamily.Text))
                 .margins("0cm", "0cm", "1cm", "0cm")
-                .fontFamilly("Arial")
+                .fontFamily("Arial")
                 .fontSize("15pt")
                 .color("#000000");
 
         styleProcessor.setStyle(stylesOfficeStyles.newStyle(Text_20_2, OdfStyleFamily.Text))
                 .margins("0cm", "0cm", "0cm", "0cm")
-                .fontFamilly("Arial")
+                .fontFamily("Arial")
                 .fontSize("11pt")
                 .color("#000000");
 
         styleProcessor.setStyle(stylesOfficeStyles.newStyle(Text_20_3, OdfStyleFamily.Text))
                 .margins("0cm", "0cm", "0cm", "0cm")
-                .fontFamilly("Arial")
+                .fontFamily("Arial")
                 .fontSize("11pt")
                 .color("#000000")
                 .fontStyle("italic");
@@ -660,7 +435,7 @@ public class OdtService {
             return this;
         }
 
-        public OdfStyleProcessor fontFamilly(String value) {
+        public OdfStyleProcessor fontFamily(String value) {
             this.style.setProperty(StyleTextPropertiesElement.FontFamily, value);
             this.style.setProperty(StyleTextPropertiesElement.FontName, value);
             return this;
@@ -700,9 +475,8 @@ public class OdtService {
             return this;
         }
 
-        public OdfStyleProcessor textAlign(String value) {
+        public void textAlign(String value) {
             this.style.setProperty(StyleParagraphPropertiesElement.TextAlign, value);
-            return this;
         }
     }
 

--- a/src/main/java/gov/cabinetoffice/gap/service/OdtService.java
+++ b/src/main/java/gov/cabinetoffice/gap/service/OdtService.java
@@ -39,7 +39,7 @@ public class OdtService {
     private static final String APPLICANT_ORG_CHARITY_NUMBER = "APPLICANT_ORG_CHARITY_NUMBER";
     private static final String APPLICANT_ORG_COMPANIES_HOUSE = "APPLICANT_ORG_COMPANIES_HOUSE";
     private static final String APPLICANT_AMOUNT = "APPLICANT_AMOUNT";
-    private static final String BENEFICIARY_LOCATION = "BENEFICIARY_LOCATION";
+    private static final String BENEFICIARY_LOCATION = "BENEFITIARY_LOCATION";
     private static final String APPLICANT_ORG_TYPE_INDIVIDUAL = "I am applying as an individual";
     private static final String Heading_20_1 = "Heading_20_1";
     private static final String Heading_20_2 = "Heading_20_2";
@@ -47,6 +47,8 @@ public class OdtService {
     private static final String Text_20_1 = "Text_20_1";
     private static final String Text_20_2 = "Text_20_2";
     private static final String Text_20_3 = "Text_20_3";
+
+    private static final String UUID_REGEX = "[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}";
 
     OdtService() {
     }
@@ -86,15 +88,15 @@ public class OdtService {
                 populateRequiredChecksSection(submission, documentText, contentDom,
                         requiredCheckSection, fundingSectionName, odt);
 
-                addPageBreak(contentDom, odt);
                 AtomicInteger count = new AtomicInteger(3); //2 sections already added
-                documentText.appendChild(new OdfTextParagraph(contentDom)
-                        .addStyledContentWhitespace(Heading_20_2, "Custom sections"));
+
+                if(submission.getSections().stream().anyMatch(section -> section.getSectionId().matches(UUID_REGEX))) {
+                    addPageBreak(contentDom, odt);
+                    documentText.appendChild(new OdfTextParagraph(contentDom)
+                            .addStyledContentWhitespace(Heading_20_2, "Custom sections"));
+                }
                 submission.getSections().forEach(section -> {
-                    if (!Objects.equals(section.getSectionId(), ELIGIBILITY_SECTION_ID) &&
-                            !Objects.equals(section.getSectionId(), ESSENTIAL_SECTION_ID) &&
-                            !Objects.equals(section.getSectionId(), ORGANISATION_DETAILS_SECTION_ID) &&
-                            !Objects.equals(section.getSectionId(), FUNDING_DETAILS_SECTION_ID)) {
+                    if (section.getSectionId().matches(UUID_REGEX)) {
                         populateQuestionResponseTable(count, section, documentText, contentDom, odt);
                     }
                 });
@@ -132,25 +134,29 @@ public class OdtService {
         OdfTable table;
 
         if(isIndividual){
-            table = OdfTable.newTable(odt, 3, 2);
+            table = OdfTable.newTable(odt, 4, 2);
             table.getRowByIndex(0).getCellByIndex(0).setStringValue("Lead Applicant");
             table.getRowByIndex(0).getCellByIndex(1).setStringValue(email);
-            table.getRowByIndex(1).getCellByIndex(0).setStringValue("Applying for");
-            table.getRowByIndex(1).getCellByIndex(1).setStringValue(submission.getSchemeName());
-            table.getRowByIndex(2).getCellByIndex(0).setStringValue("Submitted on");
-            table.getRowByIndex(2).getCellByIndex(1).setStringValue(Objects.equals(null,
-                    submission.getSubmittedDate())
-                    ? "Not yet submitted" : String.valueOf(submission.getSubmittedDate()));
-        } else {
-            table = OdfTable.newTable(odt, 4, 2);
-            table.getRowByIndex(0).getCellByIndex(0).setStringValue("Organisation");
-            table.getRowByIndex(0).getCellByIndex(1).setStringValue(submission.getLegalName());
-            table.getRowByIndex(1).getCellByIndex(0).setStringValue("Lead Applicant");
-            table.getRowByIndex(1).getCellByIndex(1).setStringValue(email);
+            table.getRowByIndex(1).getCellByIndex(0).setStringValue("GAP ID");
+            table.getRowByIndex(1).getCellByIndex(1).setStringValue(submission.getGapId());
             table.getRowByIndex(2).getCellByIndex(0).setStringValue("Applying for");
             table.getRowByIndex(2).getCellByIndex(1).setStringValue(submission.getSchemeName());
             table.getRowByIndex(3).getCellByIndex(0).setStringValue("Submitted on");
             table.getRowByIndex(3).getCellByIndex(1).setStringValue(Objects.equals(null,
+                    submission.getSubmittedDate())
+                    ? "Not yet submitted" : String.valueOf(submission.getSubmittedDate()));
+        } else {
+            table = OdfTable.newTable(odt, 5, 2);
+            table.getRowByIndex(0).getCellByIndex(0).setStringValue("Organisation");
+            table.getRowByIndex(0).getCellByIndex(1).setStringValue(submission.getLegalName());
+            table.getRowByIndex(1).getCellByIndex(0).setStringValue("Lead Applicant");
+            table.getRowByIndex(1).getCellByIndex(1).setStringValue(email);
+            table.getRowByIndex(2).getCellByIndex(0).setStringValue("GAP ID");
+            table.getRowByIndex(2).getCellByIndex(1).setStringValue(submission.getGapId());
+            table.getRowByIndex(3).getCellByIndex(0).setStringValue("Applying for");
+            table.getRowByIndex(3).getCellByIndex(1).setStringValue(submission.getSchemeName());
+            table.getRowByIndex(4).getCellByIndex(0).setStringValue("Submitted on");
+            table.getRowByIndex(4).getCellByIndex(1).setStringValue(Objects.equals(null,
                     submission.getSubmittedDate())
                     ? "Not yet submitted" : String.valueOf(submission.getSubmittedDate()));
 

--- a/src/main/java/gov/cabinetoffice/gap/service/OdtService.java
+++ b/src/main/java/gov/cabinetoffice/gap/service/OdtService.java
@@ -7,14 +7,22 @@ import org.odftoolkit.odfdom.doc.OdfTextDocument;
 import org.odftoolkit.odfdom.doc.table.OdfTable;
 import org.odftoolkit.odfdom.dom.OdfContentDom;
 import org.odftoolkit.odfdom.dom.element.office.OfficeTextElement;
+import org.odftoolkit.odfdom.dom.element.style.StyleMasterPageElement;
+import org.odftoolkit.odfdom.dom.element.style.StyleParagraphPropertiesElement;
+import org.odftoolkit.odfdom.dom.element.style.StyleTextPropertiesElement;
 import org.odftoolkit.odfdom.dom.element.table.TableTableElement;
+import org.odftoolkit.odfdom.dom.element.text.TextPElement;
+import org.odftoolkit.odfdom.dom.style.OdfStyleFamily;
+import org.odftoolkit.odfdom.dom.style.OdfStylePropertySet;
+import org.odftoolkit.odfdom.dom.style.props.OdfPageLayoutProperties;
+import org.odftoolkit.odfdom.incubator.doc.office.OdfOfficeAutomaticStyles;
+import org.odftoolkit.odfdom.incubator.doc.office.OdfOfficeStyles;
+import org.odftoolkit.odfdom.incubator.doc.style.OdfStyle;
+import org.odftoolkit.odfdom.incubator.doc.style.OdfStylePageLayout;
 import org.odftoolkit.odfdom.incubator.doc.text.OdfTextHeading;
 import org.odftoolkit.odfdom.incubator.doc.text.OdfTextParagraph;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import java.time.ZoneId;
-import java.time.format.DateTimeFormatter;
 import java.util.Objects;
 import java.util.concurrent.atomic.AtomicInteger;
 
@@ -25,7 +33,6 @@ public class OdtService {
     private static final String ESSENTIAL_SECTION_ID = "ESSENTIAL";
     private static final String ORGANISATION_DETAILS_SECTION_ID = "ORGANISATION_DETAILS";
     private static final String FUNDING_DETAILS_SECTION_ID = "FUNDING_DETAILS";
-
     private static final String APPLICANT_TYPE = "APPLICANT_TYPE";
     private static final String APPLICANT_ORG_NAME = "APPLICANT_ORG_NAME";
     private static final String APPLICANT_ORG_ADDRESS = "APPLICANT_ORG_ADDRESS";
@@ -34,165 +41,212 @@ public class OdtService {
     private static final String APPLICANT_AMOUNT = "APPLICANT_AMOUNT";
     private static final String BENEFITIARY_LOCATION = "BENEFITIARY_LOCATION";
     private static final String APPLICANT_ORG_TYPE_INDIVIDUAL = "I am applying as an individual";
+    private static final String Heading_20_1 = "Heading_20_1";
+    private static final String Heading_20_2 = "Heading_20_2";
+    private static final String Heading_20_3 = "Heading_20_3";
+    private static final String Text_20_1 = "Text_20_1";
+    private static final String Text_20_2 = "Text_20_2";
+    private static final String Text_20_3 = "Text_20_3";
 
     OdtService() {
     }
 
     public static void generateSingleOdt(final Submission submission, final String filename) throws Exception {
-        try {
-            Integer schemeVersion = submission.getSchemeVersion();
-            OdfTextDocument odt = OdfTextDocument.newTextDocument();
-            OdfContentDom contentDom = odt.getContentDom();
-            OfficeTextElement documentText = odt.getContentRoot();
-            String largeHeadingStyle = "Heading_20_2";
-            String smallHeadingStyle = "Heading_20_10";
-            DateTimeFormatter dateTimeFormatter = DateTimeFormatter.ofPattern("dd/MM/yyyy").withZone(ZoneId.of("GMT"));
-            final String fundingSectionName = schemeVersion == 1 ? ESSENTIAL_SECTION_ID : FUNDING_DETAILS_SECTION_ID;
-            final String requiredCheckSectionName = schemeVersion == 1 ? ESSENTIAL_SECTION_ID : ORGANISATION_DETAILS_SECTION_ID;
+//        try {
+//            Integer schemeVersion = submission.getSchemeVersion();
+//            OdfTextDocument odt = OdfTextDocument.newTextDocument();
+//            OdfContentDom contentDom = odt.getContentDom();
+//            OfficeTextElement documentText = odt.getContentRoot();
+//            String largeHeadingStyle = "Heading_20_2";
+//            String smallHeadingStyle = "Heading_20_10";
+//            DateTimeFormatter dateTimeFormatter = DateTimeFormatter.ofPattern("dd/MM/yyyy").withZone(ZoneId.of("GMT"));
+//            final String fundingSectionName = schemeVersion == 1 ? ESSENTIAL_SECTION_ID : FUNDING_DETAILS_SECTION_ID;
+//            final String requiredCheckSectionName = schemeVersion == 1 ? ESSENTIAL_SECTION_ID : ORGANISATION_DETAILS_SECTION_ID;
+//
+//            final SubmissionSection eligibilitySection = submission.getSectionById(ELIGIBILITY_SECTION_ID);
+//            final SubmissionSection requiredCheckSection = submission.getSectionById(requiredCheckSectionName);
+//            final String orgType = requiredCheckSection.getQuestionById(APPLICANT_TYPE).getResponse();
+//            final Boolean isIndividual = Objects.equals(orgType, APPLICANT_ORG_TYPE_INDIVIDUAL);
+//
+//            OdfTextParagraph sectionBreak = new OdfTextParagraph(contentDom);
+//            sectionBreak.addContentWhitespace("\n\n");
+//
+//            // Add top-level submission info
+//            OdfTextHeading mainHeading = new OdfTextHeading(contentDom);
+//            mainHeading.addStyledContentWhitespace(smallHeadingStyle, "Scheme applied for: " +
+//                    submission.getSchemeName() + "\n\n");
+//            final String nameHeadingPrefix = isIndividual ? "Applicant" : "Organisation";
+//            mainHeading.addStyledContentWhitespace(smallHeadingStyle, nameHeadingPrefix + " name: " +
+//                    submission.getLegalName() + "\n\n");
+//            mainHeading.addStyledContentWhitespace(smallHeadingStyle, "Gap ID: " +
+//                    submission.getGapId() + "\n\n");
+//            mainHeading.addStyledContentWhitespace(smallHeadingStyle, "Submitted date: " +
+//                    dateTimeFormatter.format(submission.getSubmittedDate()) + "\n\n");
+//            mainHeading.addStyledContentWhitespace(smallHeadingStyle, "Amount applied for: £" +
+//                    submission.getQuestionById(fundingSectionName, APPLICANT_AMOUNT).getResponse());
+//            documentText.appendChild(mainHeading);
+//
+//            // ELIGIBILITY SECTION
+//            OdfTextHeading eligibilityHeading = new OdfTextHeading(contentDom);
+//            OdfTextParagraph eligibilityStatement = new OdfTextParagraph(contentDom);
+//            OdfTextParagraph eligibilityResponse = new OdfTextParagraph(contentDom);
+//
+//            documentText.appendChild(sectionBreak.cloneElement());
+//            eligibilityHeading.addStyledContent(largeHeadingStyle, "Section 1 - " +
+//                    eligibilitySection.getSectionTitle());
+//            documentText.appendChild(eligibilityHeading);
+//            eligibilityStatement.addStyledContentWhitespace(smallHeadingStyle, "Eligibility statement: \n" +
+//                    eligibilitySection.getQuestionById(ELIGIBILITY_SECTION_ID).getDisplayText());
+//            eligibilityResponse.addContentWhitespace("Applicant selected: \n" +
+//                    eligibilitySection.getQuestionById(ELIGIBILITY_SECTION_ID).getResponse());
+//            documentText.appendChild(eligibilityStatement);
+//            documentText.appendChild(eligibilityResponse);
+//
+//            // ESSENTIAL SECTION or ORGANISATION_DETAILS/FUNDING_DETAILS SECTION based on scheme version
+//
+//            OdfTextHeading requiredCheckHeading = new OdfTextHeading(contentDom);
+//            OdfTextParagraph locationQuestion = new OdfTextParagraph(contentDom);
+//            OdfTextParagraph locationResponse = new OdfTextParagraph(contentDom);
+//
+//            documentText.appendChild(sectionBreak.cloneElement());
+//            requiredCheckHeading.addStyledContent(largeHeadingStyle, "Section 2 - " +
+//                    "Required checks");
+//            documentText.appendChild(requiredCheckHeading);
+//            documentText.appendChild(new OdfTextParagraph(contentDom).addContentWhitespace(""));
+//
+//            documentText.appendChild(generateEssentialTable(documentText, requiredCheckSection, submission.getEmail()));
+//
+//            locationQuestion.addStyledContent(smallHeadingStyle, "Where this funding will be spent");
+//
+//            locationResponse.addContentWhitespace(String.join(",\n",
+//                    submission.getQuestionById(fundingSectionName, BENEFITIARY_LOCATION).getMultiResponse()));
+//
+//            documentText.appendChild(locationQuestion);
+//            documentText.appendChild(locationResponse);
+//
+//
+//            // CUSTOM SECTIONS
+//            AtomicInteger count = new AtomicInteger(3); // custom section starts from 3
+//            submission.getSections().forEach(section -> {
+//                // ignore eligibility and essential section
+//                if (!Objects.equals(section.getSectionId(), ELIGIBILITY_SECTION_ID) &&
+//                        !Objects.equals(section.getSectionId(), ESSENTIAL_SECTION_ID) &&
+//                        !Objects.equals(section.getSectionId(), ORGANISATION_DETAILS_SECTION_ID) &&
+//                        !Objects.equals(section.getSectionId(), FUNDING_DETAILS_SECTION_ID)) {
+//
+//                    documentText.appendChild(sectionBreak.cloneElement());
+//
+//                    // Add section title
+//                    OdfTextHeading sectionHeading = new OdfTextHeading(contentDom);
+//                    sectionHeading.addStyledContent(largeHeadingStyle, "Section " + count + " - " +
+//                            section.getSectionTitle());
+//                    documentText.appendChild(sectionHeading);
+//
+//                    // Add the questions
+//                    section.getQuestions().forEach(question -> {
+//                        OdfTextParagraph questionParagraph = new OdfTextParagraph(contentDom);
+//                        OdfTextParagraph responseParagraph = new OdfTextParagraph(contentDom);
+//                        questionParagraph.addStyledContent(smallHeadingStyle, question.getFieldTitle());
+//
+//                        switch (question.getResponseType()) {
+//                            case AddressInput:
+//                            case MultipleSelection:
+//                                if (question.getMultiResponse() != null) {
+//                                    responseParagraph.addContentWhitespace(String.join(",\n",
+//                                            question.getMultiResponse()) + "\n");
+//                                } else {
+//                                    responseParagraph.addContentWhitespace("\n");
+//                                }
+//                                break;
+//                            case SingleFileUpload:
+//                                if (question.getResponse() != null) {
+//                                    int index = question.getResponse().lastIndexOf(".");
+//
+//                                    responseParagraph.addContentWhitespace("File name: " + question.getResponse().substring(0, index) + "\n");
+//                                    responseParagraph.addContentWhitespace("File extension: " + question.getResponse().substring(index + 1) + "\n");
+//                                } else {
+//                                    responseParagraph.addContentWhitespace("\n");
+//                                }
+//                                break;
+//                            case Date:
+//                                if (question.getMultiResponse() != null) {
+//                                    responseParagraph.addContentWhitespace(String.join("-",
+//                                            question.getMultiResponse()) + "\n");
+//                                } else {
+//                                    responseParagraph.addContentWhitespace("\n");
+//                                }
+//                                break;
+//                            default:
+//                                responseParagraph.addContentWhitespace(question.getResponse() + "\n");
+//                                break;
+//                        }
+//
+//                        documentText.appendChild(questionParagraph);
+//                        documentText.appendChild(responseParagraph);
+//                    });
+//
+//                    count.getAndIncrement();
+//                }
+//            });
+//
+//            odt.save(String.format("/tmp/%s.odt", filename));
+//            odt.close();
+//        } catch (Exception e) {
+//            logger.error("Could not generate ODT for given submission", e);
+//            throw e;
+//        }
+//        logger.info("ODT file generated successfully");
+            try {
+                OdfStyleProcessor styleProcessor = new OdfStyleProcessor();
+                int schemeVersion = submission.getSchemeVersion();
+                OdfTextDocument odt = OdfTextDocument.newTextDocument();
+                OdfOfficeStyles stylesOfficeStyles = odt.getOrCreateDocumentStyles();
+                OdfContentDom contentDom = odt.getContentDom();
+                OfficeTextElement documentText = odt.getContentRoot();
+                final String fundingSectionName = schemeVersion == 1 ?
+                        ESSENTIAL_SECTION_ID : FUNDING_DETAILS_SECTION_ID;
+                final String requiredCheckSectionName = schemeVersion == 1 ?
+                        ESSENTIAL_SECTION_ID : ORGANISATION_DETAILS_SECTION_ID;
+                final SubmissionSection requiredCheckSection = submission.getSectionById(requiredCheckSectionName);
+                final String orgType = requiredCheckSection.getQuestionById(APPLICANT_TYPE).getResponse();
+                final boolean isIndividual = Objects.equals(orgType, APPLICANT_ORG_TYPE_INDIVIDUAL);
+                final String email = submission.getEmail();
 
-            final SubmissionSection eligibilitySection = submission.getSectionById(ELIGIBILITY_SECTION_ID);
-            final SubmissionSection requiredCheckSection = submission.getSectionById(requiredCheckSectionName);
-            final String orgType = requiredCheckSection.getQuestionById(APPLICANT_TYPE).getResponse();
-            final Boolean isIndividual = Objects.equals(orgType, APPLICANT_ORG_TYPE_INDIVIDUAL);
+                setOfficeStyles(odt, styleProcessor, stylesOfficeStyles);
 
-            OdfTextParagraph sectionBreak = new OdfTextParagraph(contentDom);
-            sectionBreak.addContentWhitespace("\n\n");
+                populateHeadingSection(submission, documentText, contentDom,
+                        isIndividual, odt, email);
 
-            // Add top-level submission info
-            OdfTextHeading mainHeading = new OdfTextHeading(contentDom);
-            mainHeading.addStyledContentWhitespace(smallHeadingStyle, "Scheme applied for: " +
-                    submission.getSchemeName() + "\n\n");
-            final String nameHeadingPrefix = isIndividual ? "Applicant" : "Organisation";
-            mainHeading.addStyledContentWhitespace(smallHeadingStyle, nameHeadingPrefix + " name: " +
-                    submission.getLegalName() + "\n\n");
-            mainHeading.addStyledContentWhitespace(smallHeadingStyle, "Gap ID: " +
-                    submission.getGapId() + "\n\n");
-            mainHeading.addStyledContentWhitespace(smallHeadingStyle, "Submitted date: " +
-                    dateTimeFormatter.format(submission.getSubmittedDate()) + "\n\n");
-            mainHeading.addStyledContentWhitespace(smallHeadingStyle, "Amount applied for: £" +
-                    submission.getQuestionById(fundingSectionName, APPLICANT_AMOUNT).getResponse());
-            documentText.appendChild(mainHeading);
+                odt.getContentRoot().setTextUseSoftPageBreaksAttribute(true);
 
-            // ELIGIBILITY SECTION
-            OdfTextHeading eligibilityHeading = new OdfTextHeading(contentDom);
-            OdfTextParagraph eligibilityStatement = new OdfTextParagraph(contentDom);
-            OdfTextParagraph eligibilityResponse = new OdfTextParagraph(contentDom);
+                addPageBreak(contentDom, odt);
 
-            documentText.appendChild(sectionBreak.cloneElement());
-            eligibilityHeading.addStyledContent(largeHeadingStyle, "Section 1 - " +
-                    eligibilitySection.getSectionTitle());
-            documentText.appendChild(eligibilityHeading);
-            eligibilityStatement.addStyledContentWhitespace(smallHeadingStyle, "Eligibility statement: \n" +
-                    eligibilitySection.getQuestionById(ELIGIBILITY_SECTION_ID).getDisplayText());
-            eligibilityResponse.addContentWhitespace("Applicant selected: \n" +
-                    eligibilitySection.getQuestionById(ELIGIBILITY_SECTION_ID).getResponse());
-            documentText.appendChild(eligibilityStatement);
-            documentText.appendChild(eligibilityResponse);
+                OdfTextParagraph sectionBreak = new OdfTextParagraph(contentDom);
 
-            // ESSENTIAL SECTION or ORGANISATION_DETAILS/FUNDING_DETAILS SECTION based on scheme version
+                populateEligibilitySection(submission, documentText, contentDom, sectionBreak);
 
-            OdfTextHeading requiredCheckHeading = new OdfTextHeading(contentDom);
-            OdfTextParagraph locationQuestion = new OdfTextParagraph(contentDom);
-            OdfTextParagraph locationResponse = new OdfTextParagraph(contentDom);
+                addPageBreak(contentDom, odt);
 
-            documentText.appendChild(sectionBreak.cloneElement());
-            requiredCheckHeading.addStyledContent(largeHeadingStyle, "Section 2 - " +
-                    "Required checks");
-            documentText.appendChild(requiredCheckHeading);
-            documentText.appendChild(new OdfTextParagraph(contentDom).addContentWhitespace(""));
+                populateRequiredChecksSection(submission, documentText, contentDom,
+                        requiredCheckSection, fundingSectionName, odt);
 
-            documentText.appendChild(generateEssentialTable(documentText, requiredCheckSection, submission.getEmail()));
-
-            locationQuestion.addStyledContent(smallHeadingStyle, "Where this funding will be spent");
-
-            locationResponse.addContentWhitespace(String.join(",\n",
-                    submission.getQuestionById(fundingSectionName, BENEFITIARY_LOCATION).getMultiResponse()));
-
-            documentText.appendChild(locationQuestion);
-            documentText.appendChild(locationResponse);
-
-
-            // CUSTOM SECTIONS
-            AtomicInteger count = new AtomicInteger(3); // custom section starts from 3
-            submission.getSections().forEach(section -> {
-                // ignore eligibility and essential section
-                if (!Objects.equals(section.getSectionId(), ELIGIBILITY_SECTION_ID) &&
-                        !Objects.equals(section.getSectionId(), ESSENTIAL_SECTION_ID) &&
-                        !Objects.equals(section.getSectionId(), ORGANISATION_DETAILS_SECTION_ID) &&
-                        !Objects.equals(section.getSectionId(), FUNDING_DETAILS_SECTION_ID)) {
-
-                    documentText.appendChild(sectionBreak.cloneElement());
-
-                    // Add section title
-                    OdfTextHeading sectionHeading = new OdfTextHeading(contentDom);
-                    sectionHeading.addStyledContent(largeHeadingStyle, "Section " + count + " - " +
-                            section.getSectionTitle());
-                    documentText.appendChild(sectionHeading);
-
-                    // Add the questions
-                    section.getQuestions().forEach(question -> {
-                        OdfTextParagraph questionParagraph = new OdfTextParagraph(contentDom);
-                        OdfTextParagraph responseParagraph = new OdfTextParagraph(contentDom);
-                        questionParagraph.addStyledContent(smallHeadingStyle, question.getFieldTitle());
-
-                        switch (question.getResponseType()) {
-                            case AddressInput:
-                            case MultipleSelection:
-                                if (question.getMultiResponse() != null) {
-                                    final String response = String.join(",\n",
-                                            question.getMultiResponse());
-                                    responseParagraph.addContentWhitespace((response.isEmpty() ? "Not provided" : response) + "\n");
-                                } else {
-                                    responseParagraph.addContentWhitespace("Not provided" +  "\n");
-                                }
-                                break;
-                            case SingleFileUpload:
-                                if (question.getResponse() != null) {
-                                    int index = question.getResponse().lastIndexOf(".");
-
-                                    responseParagraph.addContentWhitespace("File name: " + question.getResponse().substring(0, index) + "\n");
-                                    responseParagraph.addContentWhitespace("File extension: " + question.getResponse().substring(index + 1) + "\n");
-                                } else {
-                                    responseParagraph.addContentWhitespace("Not provided" +  "\n");
-                                }
-                                break;
-                            case Date:
-                                if (question.getMultiResponse() != null) {
-                                    final String date = String.join("-", question.getMultiResponse());
-                                    responseParagraph.addContentWhitespace((date.equals("--") ? "Not provided" : date) + "\n");
-                                } else {
-                                    responseParagraph.addContentWhitespace("Not provided" +  "\n");
-                                }
-                                break;
-                            case YesNo:
-                            case Dropdown:
-                            case ShortAnswer:
-                            case LongAnswer:
-                            case Numeric:
-                                if(question.getResponse() == null || question.getResponse().isEmpty()) {
-                                    responseParagraph.addContentWhitespace("Not provided" + "\n");
-                                } else {
-                                    responseParagraph.addContentWhitespace(question.getResponse() + "\n");
-                                }
-                                break;
-                            default:
-                                responseParagraph.addContentWhitespace(question.getResponse() + "\n");
-                                break;
-                        }
-
-                        documentText.appendChild(questionParagraph);
-                        documentText.appendChild(responseParagraph);
-                    });
-
-                    count.getAndIncrement();
-                }
-            });
-
-            odt.save(String.format("/tmp/%s.odt", filename));
-            odt.close();
-        } catch (Exception e) {
-            logger.error("Could not generate ODT for given submission", e);
-            throw e;
+                addPageBreak(contentDom, odt);
+                AtomicInteger count = new AtomicInteger(3); //2 sections already added
+                documentText.appendChild(new OdfTextParagraph(contentDom)
+                        .addStyledContentWhitespace(Heading_20_2, "Custom sections"));
+                submission.getSections().forEach(section -> {
+                    if (!Objects.equals(section.getSectionId(), ELIGIBILITY_SECTION_ID) &&
+                            !Objects.equals(section.getSectionId(), ESSENTIAL_SECTION_ID) &&
+                            !Objects.equals(section.getSectionId(), ORGANISATION_DETAILS_SECTION_ID) &&
+                            !Objects.equals(section.getSectionId(), FUNDING_DETAILS_SECTION_ID)) {
+                        populateQuestionResponseTable(count, section, documentText, contentDom, odt);
+                    }
+                });
+                odt.save(String.format("/tmp/%s.odt", filename));
+                odt.close();
+            } catch (Exception e) {
+                logger.error("Could not generate ODT for given submission", e);
+                throw e;
         }
         logger.info("ODT file generated successfully");
     }
@@ -201,47 +255,308 @@ public class OdtService {
      * Wouldn't you know it, there's no good docs on generating a table by hand using ODFDOM.
      * There might be a better way to do it, but it sure isn't documented anywhere.
      */
-    private static TableTableElement generateEssentialTable(final OfficeTextElement documentText,
-                                                            final SubmissionSection section,
-                                                            final String email) {
-        OdfTable odfTable = OdfTable.newTable(documentText, 7, 2);
+//    private static TableTableElement generateEssentialTable(final OfficeTextElement documentText,
+//                                                            final SubmissionSection section,
+//                                                            final String email) {
+//        OdfTable odfTable = OdfTable.newTable(documentText, 7, 2);
+//
+//        final String orgType = section.getQuestionById(APPLICANT_TYPE).getResponse();
+//        final Boolean isIndividual = Objects.equals(orgType, APPLICANT_ORG_TYPE_INDIVIDUAL);
+//
+//        final String orgNameHeading = isIndividual ? "Applicant name" : "Legal name of organisation";
+//        odfTable.getRowByIndex(0).getCellByIndex(0).setStringValue(orgNameHeading);
+//        odfTable.getRowByIndex(0).getCellByIndex(1).setStringValue(section.getQuestionById(APPLICANT_ORG_NAME).getResponse());
+//
+//        odfTable.getRowByIndex(1).getCellByIndex(0).setStringValue("Type of organisation");
+//        odfTable.getRowByIndex(1).getCellByIndex(1).setStringValue(orgType);
+//
+//        String[] applicantOrgAddress = section.getQuestionById(APPLICANT_ORG_ADDRESS).getMultiResponse();
+//
+//        odfTable.getRowByIndex(2).getCellByIndex(0).setStringValue("The first line of address for the organisation");
+//        odfTable.getRowByIndex(2).getCellByIndex(1).setStringValue(applicantOrgAddress[0]);
+//
+//        odfTable.getRowByIndex(3).getCellByIndex(0).setStringValue("The second line of address for the organisation");
+//        odfTable.getRowByIndex(3).getCellByIndex(1).setStringValue(applicantOrgAddress[1]);
+//
+//        odfTable.getRowByIndex(4).getCellByIndex(0).setStringValue("The town of the address for the organisation");
+//        odfTable.getRowByIndex(4).getCellByIndex(1).setStringValue(applicantOrgAddress[2]);
+//
+//        odfTable.getRowByIndex(5).getCellByIndex(0).setStringValue("The county of the address for the organisation");
+//        odfTable.getRowByIndex(5).getCellByIndex(1).setStringValue(applicantOrgAddress[3]);
+//
+//        odfTable.getRowByIndex(6).getCellByIndex(0)
+//                .setStringValue("The postcode of the address for the organisation");
+//        odfTable.getRowByIndex(6).getCellByIndex(1)
+//                .setStringValue(applicantOrgAddress[4]);
+//
+//        odfTable.getRowByIndex(7).getCellByIndex(0)
+//                .setStringValue("The email address for the lead applicant");
+//        odfTable.getRowByIndex(7).getCellByIndex(1)
+//                .setStringValue(email);
+//
+//        Integer index = 8;
+//        final Boolean hasCharityCommissionNumber = section
+//                .mayGetQuestionById(APPLICANT_ORG_CHARITY_NUMBER)
+//                .isPresent();
+//        if (hasCharityCommissionNumber) {
+//            odfTable.getRowByIndex(index)
+//                    .getCellByIndex(0)
+//                    .setStringValue("Charities Commission number if the organisation has one (if blank, number has not been entered)");
+//            odfTable.getRowByIndex(index)
+//                    .getCellByIndex(1)
+//                    .setStringValue(section
+//                            .mayGetQuestionById(APPLICANT_ORG_CHARITY_NUMBER)
+//                            .map(SubmissionQuestion::getResponse)
+//                            .orElse("")
+//                    );
+//            index++;
+//        }
+//
+//        final Boolean hasCompaniesHouseNumber = section
+//                .mayGetQuestionById(APPLICANT_ORG_COMPANIES_HOUSE)
+//                .isPresent();
+//        if (hasCompaniesHouseNumber) {
+//            odfTable.getRowByIndex(index)
+//                    .getCellByIndex(0)
+//                    .setStringValue("Companies House number if the organisation has one (if blank, number has not been entered)");
+//            odfTable.getRowByIndex(index)
+//                    .getCellByIndex(1)
+//                    .setStringValue(section
+//                            .mayGetQuestionById(APPLICANT_ORG_COMPANIES_HOUSE)
+//                            .map(SubmissionQuestion::getResponse)
+//                            .orElse("")
+//                    );
+//        }
+//
+//        return odfTable.getOdfElement();
+//    }
+//}
 
+    private static void addPageBreak(OdfContentDom contentDocument, OdfTextDocument doc) throws Exception {
+        final OdfOfficeAutomaticStyles styles = contentDocument.getAutomaticStyles();
+        final OdfStyle style = styles.newStyle(OdfStyleFamily.Paragraph);
+        style.newStyleParagraphPropertiesElement().setFoBreakBeforeAttribute("page");
+        final TextPElement page = doc.getContentRoot().newTextPElement();
+        page.setStyleName(style.getStyleNameAttribute());
+    }
+
+    private static void populateHeadingSection(final Submission submission,
+                                               final OfficeTextElement documentText,
+                                               final OdfContentDom contentDom,
+                                               final boolean isIndividual,
+                                               final OdfTextDocument odt,
+                                               final String email){
+
+        OdfTextHeading h1 = new OdfTextHeading(contentDom);
+        OdfTextHeading h2 = new OdfTextHeading(contentDom);
+        OdfTextParagraph p = new OdfTextParagraph(contentDom);
+
+        h1.addStyledContentWhitespace(Heading_20_1, submission.getLegalName());
+        p.addStyledContentWhitespace(Text_20_1, "Application for " + submission.getSchemeName() + "\n");
+        h2.addStyledContentWhitespace(Heading_20_2, "Application details");
+        OdfTable table;
+
+        if(isIndividual){
+            table = OdfTable.newTable(odt, 3, 2);
+            table.getRowByIndex(0).getCellByIndex(0).setStringValue("Lead Applicant");
+            table.getRowByIndex(0).getCellByIndex(1).setStringValue(email);
+            table.getRowByIndex(1).getCellByIndex(0).setStringValue("Applying for");
+            table.getRowByIndex(1).getCellByIndex(1).setStringValue(submission.getSchemeName());
+            table.getRowByIndex(2).getCellByIndex(0).setStringValue("Submitted on");
+            table.getRowByIndex(2).getCellByIndex(1).setStringValue(Objects.equals(null,
+                    submission.getSubmittedDate())
+                    ? "Not yet submitted" : String.valueOf(submission.getSubmittedDate()));
+        } else {
+            table = OdfTable.newTable(odt, 4, 2);
+            table.getRowByIndex(0).getCellByIndex(0).setStringValue("Organisation");
+            table.getRowByIndex(0).getCellByIndex(1).setStringValue(submission.getLegalName());
+            table.getRowByIndex(1).getCellByIndex(0).setStringValue("Lead Applicant");
+            table.getRowByIndex(1).getCellByIndex(1).setStringValue(email);
+            table.getRowByIndex(2).getCellByIndex(0).setStringValue("Applying for");
+            table.getRowByIndex(2).getCellByIndex(1).setStringValue(submission.getSchemeName());
+            table.getRowByIndex(3).getCellByIndex(0).setStringValue("Submitted on");
+            table.getRowByIndex(3).getCellByIndex(1).setStringValue(Objects.equals(null,
+                    submission.getSubmittedDate())
+                    ? "Not yet submitted" : String.valueOf(submission.getSubmittedDate()));
+
+        }
+        documentText.appendChild(h1);
+        documentText.appendChild(p);
+        documentText.appendChild(h2);
+        documentText.appendChild(table.getOdfElement());
+    }
+
+    private static void populateRequiredChecksSection(final Submission submission,
+                                                      final OfficeTextElement documentText,
+                                                      final OdfContentDom contentDom,
+                                                      final SubmissionSection requiredCheckSection,
+                                                      final String fundingSectionName,
+                                                      final OdfTextDocument odt) {
+        OdfTextHeading requiredCheckHeading = new OdfTextHeading(contentDom);
+        OdfTextHeading requiredCheckSubHeading = new OdfTextHeading(contentDom);
+        OdfTextParagraph locationQuestion = new OdfTextParagraph(contentDom);
+        final String orgType = requiredCheckSection.getQuestionById(APPLICANT_TYPE).getResponse();
+        final boolean isIndividual = Objects.equals(orgType, APPLICANT_ORG_TYPE_INDIVIDUAL);
+        final String orgNameHeading = isIndividual ? "Applicant details" : "Organisation details";
+
+        requiredCheckHeading.addStyledContentWhitespace(Heading_20_2, "Due diligence information");
+        requiredCheckSubHeading.addStyledContentWhitespace(Heading_20_3, orgNameHeading);
+
+        documentText.appendChild(requiredCheckHeading);
+        documentText.appendChild(requiredCheckSubHeading);
+        documentText.appendChild(generateEssentialTable(requiredCheckSection, odt));
+        documentText.appendChild(new OdfTextParagraph(contentDom).addContentWhitespace(""));
+        locationQuestion.addStyledContent(Heading_20_3, "Funding");
+        OdfTable table = OdfTable.newTable(odt, 2, 2);
+
+        table.getRowByIndex(0).getCellByIndex(0).setStringValue("Amount applied for");
+        table.getRowByIndex(0).getCellByIndex(1).setStringValue("£" + submission.getQuestionById(fundingSectionName, APPLICANT_AMOUNT).getResponse());
+        table.getRowByIndex(1).getCellByIndex(0).setStringValue("Where funding will be spent");
+        table.getRowByIndex(1).getCellByIndex(1).setStringValue(String.join(",\n",
+                submission.getQuestionById(fundingSectionName, BENEFITIARY_LOCATION).getMultiResponse()));
+
+        documentText.appendChild(locationQuestion);
+        documentText.appendChild(table.getOdfElement());
+    }
+
+    private static void populateEligibilitySection(final Submission submission,
+                                                   final OfficeTextElement documentText,
+                                                   final OdfContentDom contentDom,
+                                                   final OdfTextParagraph sectionBreak
+    ) {
+        final SubmissionSection eligibilitySection = submission.getSectionById(ELIGIBILITY_SECTION_ID);
+        OdfTextHeading eligibilityHeading = new OdfTextHeading(contentDom);
+        OdfTextParagraph eligibilityStatement = new OdfTextParagraph(contentDom);
+        OdfTextParagraph eligibilityResponse = new OdfTextParagraph(contentDom);
+
+        documentText.appendChild(sectionBreak);
+        eligibilityHeading.addStyledContent(Heading_20_2, "Eligibility");
+        documentText.appendChild(eligibilityHeading);
+
+        OdfTextHeading eligibilitySubHeading = new OdfTextHeading(contentDom);
+        eligibilitySubHeading.addStyledContent(Heading_20_3, "Eligibility Statement");
+        documentText.appendChild(eligibilitySubHeading);
+
+        eligibilityResponse.addStyledContentWhitespace(Text_20_3, eligibilitySection
+                .getQuestionById(ELIGIBILITY_SECTION_ID).getDisplayText() + "\n\n");
+
+        documentText.appendChild(eligibilityResponse);
+
+        eligibilityResponse.addContentWhitespace("Applicant" + (Objects.equals(eligibilitySection
+                .getQuestionById(ELIGIBILITY_SECTION_ID).getResponse(), "Yes") ?
+                " agreed to" : " did not agree to") + " the eligibility statement.");
+        documentText.appendChild(new OdfTextHeading(contentDom).addContentWhitespace("\n\n"));
+        documentText.appendChild(eligibilityStatement);
+    }
+
+    private static void populateQuestionResponseTable(AtomicInteger count,
+                                                      SubmissionSection section,
+                                                      OfficeTextElement documentText,
+                                                      OdfContentDom contentDom, OdfTextDocument odt) {
+        OdfTextHeading sectionHeading = new OdfTextHeading(contentDom);
+        sectionHeading.addStyledContentWhitespace(Heading_20_3, section.getSectionTitle());
+        documentText.appendChild(sectionHeading);
+
+        AtomicInteger questionIndex = new AtomicInteger(0);
+        OdfTable table = OdfTable.newTable(odt, section.getQuestions().size(), 2);
+        section.getQuestions().forEach(question -> {
+            populateDocumentFromQuestionResponse(question, documentText, questionIndex, table);
+            questionIndex.incrementAndGet();
+        });
+        documentText.appendChild(new OdfTextParagraph(contentDom).addContentWhitespace(""));
+        count.getAndIncrement();
+    };
+
+    private static void populateDocumentFromQuestionResponse(SubmissionQuestion question,
+                                                             OfficeTextElement documentText,
+                                                             AtomicInteger questionIndex,
+                                                             OdfTable table) {
+        switch (question.getResponseType()) {
+            case AddressInput, MultipleSelection -> {
+                table.getRowByIndex(questionIndex.get()).getCellByIndex(0).setStringValue(question.getFieldTitle());
+                if (question.getMultiResponse() != null) {
+                    table.getRowByIndex(questionIndex.get()).getCellByIndex(1).setStringValue(String.join(",\n",
+                            question.getMultiResponse()) + "\n");
+                } else {
+                    table.getRowByIndex(questionIndex.get()).getCellByIndex(1).setStringValue("Not provided");
+                }
+            }
+            case SingleFileUpload -> {
+                table.getRowByIndex(questionIndex.get()).getCellByIndex(0).setStringValue(question.getFieldTitle());
+                if (question.getResponse() != null) {
+                    int index = question.getResponse().lastIndexOf(".");
+                    String fileInfo = "File name: " + question.getResponse().substring(0, index) + "\n" +
+                            "File extension: " + question.getResponse().substring(index + 1);
+
+                    table.getRowByIndex(questionIndex.get()).getCellByIndex(1).setStringValue(fileInfo);
+
+                } else {
+                    table.getRowByIndex(questionIndex.get()).getCellByIndex(1).setStringValue("Not provided");
+                }
+            }
+            case Date -> {
+                table.getRowByIndex(questionIndex.get()).getCellByIndex(0).setStringValue(question.getFieldTitle());
+                if (question.getMultiResponse() != null) {
+                    final String date = String.join("-", question.getMultiResponse());
+                    table.getRowByIndex(questionIndex.get()).getCellByIndex(1).setStringValue(date);
+                } else {
+                    table.getRowByIndex(questionIndex.get()).getCellByIndex(1).setStringValue("Not provided");
+                }
+            }
+            case YesNo, Dropdown, ShortAnswer, LongAnswer, Numeric -> {
+                table.getRowByIndex(questionIndex.get()).getCellByIndex(0).setStringValue(question.getFieldTitle());
+                if (question.getResponse() == null || question.getResponse().isEmpty()) {
+                    table.getRowByIndex(questionIndex.get()).getCellByIndex(1).setStringValue("Not provided");
+                } else {
+                    table.getRowByIndex(questionIndex.get()).getCellByIndex(1).setStringValue(question.getResponse());
+                }
+            }
+            default ->  {
+                table.getRowByIndex(questionIndex.get()).getCellByIndex(0).setStringValue(question.getFieldTitle());
+                table.getRowByIndex(questionIndex.get()).getCellByIndex(1).setStringValue(question.getResponse());
+            }
+        }
+        documentText.appendChild(table.getOdfElement());
+    }
+
+    private static TableTableElement generateEssentialTable(
+            final SubmissionSection section,
+            OdfTextDocument doc) {
         final String orgType = section.getQuestionById(APPLICANT_TYPE).getResponse();
-        final Boolean isIndividual = Objects.equals(orgType, APPLICANT_ORG_TYPE_INDIVIDUAL);
+        final boolean isIndividual = Objects.equals(orgType, APPLICANT_ORG_TYPE_INDIVIDUAL);
+        final String orgNameHeading = isIndividual ? "Applicant name" : "Organisation Name";
+        OdfTable odfTable;
 
-        final String orgNameHeading = isIndividual ? "Applicant name" : "Legal name of organisation";
+        if(isIndividual)  {
+            odfTable = OdfTable.newTable(doc, 7, 2);
+        } else {
+            odfTable = OdfTable.newTable(doc, 9, 2);
+        }
+
         odfTable.getRowByIndex(0).getCellByIndex(0).setStringValue(orgNameHeading);
         odfTable.getRowByIndex(0).getCellByIndex(1).setStringValue(section.getQuestionById(APPLICANT_ORG_NAME).getResponse());
-
-        odfTable.getRowByIndex(1).getCellByIndex(0).setStringValue("Type of organisation");
+        odfTable.getRowByIndex(1).getCellByIndex(0).setStringValue("Organisation type");
         odfTable.getRowByIndex(1).getCellByIndex(1).setStringValue(orgType);
 
         String[] applicantOrgAddress = section.getQuestionById(APPLICANT_ORG_ADDRESS).getMultiResponse();
-
-        odfTable.getRowByIndex(2).getCellByIndex(0).setStringValue("The first line of address for the organisation");
+        odfTable.getRowByIndex(2).getCellByIndex(0).setStringValue("Address line 1");
         odfTable.getRowByIndex(2).getCellByIndex(1).setStringValue(applicantOrgAddress[0]);
-
-        odfTable.getRowByIndex(3).getCellByIndex(0).setStringValue("The second line of address for the organisation");
+        odfTable.getRowByIndex(3).getCellByIndex(0).setStringValue("Address line 2");
         odfTable.getRowByIndex(3).getCellByIndex(1).setStringValue(applicantOrgAddress[1]);
-
-        odfTable.getRowByIndex(4).getCellByIndex(0).setStringValue("The town of the address for the organisation");
+        odfTable.getRowByIndex(4).getCellByIndex(0).setStringValue("Address city");
         odfTable.getRowByIndex(4).getCellByIndex(1).setStringValue(applicantOrgAddress[2]);
-
-        odfTable.getRowByIndex(5).getCellByIndex(0).setStringValue("The county of the address for the organisation");
+        odfTable.getRowByIndex(5).getCellByIndex(0).setStringValue("Address county");
         odfTable.getRowByIndex(5).getCellByIndex(1).setStringValue(applicantOrgAddress[3]);
-
         odfTable.getRowByIndex(6).getCellByIndex(0)
-                .setStringValue("The postcode of the address for the organisation");
+                .setStringValue("Address postcode");
         odfTable.getRowByIndex(6).getCellByIndex(1)
                 .setStringValue(applicantOrgAddress[4]);
 
-        odfTable.getRowByIndex(7).getCellByIndex(0)
-                .setStringValue("The email address for the lead applicant");
-        odfTable.getRowByIndex(7).getCellByIndex(1)
-                .setStringValue(email);
-
-        Integer index = 8;
-        final Boolean hasCharityCommissionNumber = section
+        if(isIndividual){
+            return odfTable.getOdfElement();
+        }
+        int index = 7;
+        final boolean hasCharityCommissionNumber = section
                 .mayGetQuestionById(APPLICANT_ORG_CHARITY_NUMBER)
                 .isPresent();
         if (hasCharityCommissionNumber) {
@@ -257,8 +572,7 @@ public class OdtService {
                     );
             index++;
         }
-
-        final Boolean hasCompaniesHouseNumber = section
+        final boolean hasCompaniesHouseNumber = section
                 .mayGetQuestionById(APPLICANT_ORG_COMPANIES_HOUSE)
                 .isPresent();
         if (hasCompaniesHouseNumber) {
@@ -276,4 +590,120 @@ public class OdtService {
 
         return odfTable.getOdfElement();
     }
-}
+
+    private static void setOfficeStyles(OdfTextDocument outputDocument, OdfStyleProcessor styleProcessor, OdfOfficeStyles stylesOfficeStyles) {
+        // Set landscape layout
+        StyleMasterPageElement defaultPage = outputDocument.getOfficeMasterStyles().getMasterPage("Standard");
+        String pageLayoutName = defaultPage.getStylePageLayoutNameAttribute();
+        OdfStylePageLayout pageLayoutStyle = defaultPage.getAutomaticStyles().getPageLayout(pageLayoutName);
+        pageLayoutStyle.setProperty(OdfPageLayoutProperties.PrintOrientation, "Portrait");
+
+        styleProcessor.setStyle(stylesOfficeStyles.getDefaultStyle(OdfStyleFamily.Paragraph))
+                .margins("0cm", "0cm", "0cm", "0cm")
+                .fontFamilly("Arial")
+                .fontSize("11pt")
+                .textAlign("normal");
+
+
+        // Title 1
+        styleProcessor.setStyle(stylesOfficeStyles.getStyle(Heading_20_1, OdfStyleFamily.Paragraph))
+                .margins("0cm", "0cm", "0cm", "0cm").
+                color("#000000")
+                .fontWeight("normal")
+                .fontSize("26pt");
+
+        // Title 2
+        styleProcessor.setStyle(stylesOfficeStyles.getStyle(Heading_20_2, OdfStyleFamily.Paragraph))
+                .fontStyle("normal")
+                .margins("0cm", "0cm", "0.2cm", "0cm")
+                .fontWeight("normal")
+                .fontSize("20pt")
+                .color("#000000");
+
+        // Title 3
+        styleProcessor.setStyle(stylesOfficeStyles.getStyle(Heading_20_3, OdfStyleFamily.Paragraph))
+                .margins("0cm", "0cm", "0.2cm", "0cm")
+                .fontWeight("normal")
+                .fontSize("16pt");
+
+        //test
+        styleProcessor.setStyle(stylesOfficeStyles.newStyle(Text_20_1, OdfStyleFamily.Text))
+                .margins("0cm", "0cm", "1cm", "0cm")
+                .fontFamilly("Arial")
+                .fontSize("15pt")
+                .color("#000000");
+
+        styleProcessor.setStyle(stylesOfficeStyles.newStyle(Text_20_2, OdfStyleFamily.Text))
+                .margins("0cm", "0cm", "0cm", "0cm")
+                .fontFamilly("Arial")
+                .fontSize("11pt")
+                .color("#000000");
+
+        styleProcessor.setStyle(stylesOfficeStyles.newStyle(Text_20_3, OdfStyleFamily.Text))
+                .margins("0cm", "0cm", "0cm", "0cm")
+                .fontFamilly("Arial")
+                .fontSize("11pt")
+                .color("#000000")
+                .fontStyle("italic");
+    }
+
+    private static class OdfStyleProcessor {
+
+        private OdfStylePropertySet style;
+
+        public OdfStyleProcessor() {
+
+        }
+
+        public OdfStyleProcessor setStyle(OdfStylePropertySet style) {
+            this.style = style;
+            return this;
+        }
+
+        public OdfStyleProcessor fontFamilly(String value) {
+            this.style.setProperty(StyleTextPropertiesElement.FontFamily, value);
+            this.style.setProperty(StyleTextPropertiesElement.FontName, value);
+            return this;
+        }
+
+        public OdfStyleProcessor fontWeight(String value) {
+            this.style.setProperty(StyleTextPropertiesElement.FontWeight, value);
+            this.style.setProperty(StyleTextPropertiesElement.FontWeightAsian, value);
+            this.style.setProperty(StyleTextPropertiesElement.FontWeightComplex, value);
+            return this;
+        }
+
+        public OdfStyleProcessor fontStyle(String value) {
+            this.style.setProperty(StyleTextPropertiesElement.FontStyle, value);
+            this.style.setProperty(StyleTextPropertiesElement.FontStyleAsian, value);
+            this.style.setProperty(StyleTextPropertiesElement.FontStyleComplex, value);
+            return this;
+        }
+
+        public OdfStyleProcessor fontSize(String value) {
+            this.style.setProperty(StyleTextPropertiesElement.FontSize, value);
+            this.style.setProperty(StyleTextPropertiesElement.FontSizeAsian, value);
+            this.style.setProperty(StyleTextPropertiesElement.FontSizeComplex, value);
+            return this;
+        }
+
+        public OdfStyleProcessor margins(String top, String right, String bottom, String left) {
+            this.style.setProperty(StyleParagraphPropertiesElement.MarginTop, top);
+            this.style.setProperty(StyleParagraphPropertiesElement.MarginRight, right);
+            this.style.setProperty(StyleParagraphPropertiesElement.MarginBottom, bottom);
+            this.style.setProperty(StyleParagraphPropertiesElement.MarginLeft, left);
+            return this;
+        }
+
+        public OdfStyleProcessor color(String value) {
+            this.style.setProperty(StyleTextPropertiesElement.Color, value);
+            return this;
+        }
+
+        public OdfStyleProcessor textAlign(String value) {
+            this.style.setProperty(StyleParagraphPropertiesElement.TextAlign, value);
+            return this;
+        }
+    }
+
+    }

--- a/src/main/java/gov/cabinetoffice/gap/service/OdtService.java
+++ b/src/main/java/gov/cabinetoffice/gap/service/OdtService.java
@@ -23,6 +23,8 @@ import org.odftoolkit.odfdom.incubator.doc.text.OdfTextHeading;
 import org.odftoolkit.odfdom.incubator.doc.text.OdfTextParagraph;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import java.util.Arrays;
 import java.util.Objects;
 import java.util.concurrent.atomic.AtomicInteger;
 
@@ -277,7 +279,7 @@ public class OdtService {
             }
             case Date -> {
                 table.getRowByIndex(questionIndex.get()).getCellByIndex(0).setStringValue(question.getFieldTitle());
-                if (question.getMultiResponse() != null) {
+                if (question.getMultiResponse() != null && !Arrays.stream(question.getMultiResponse()).allMatch(String::isEmpty)) {
                     final String date = String.join("-", question.getMultiResponse());
                     table.getRowByIndex(questionIndex.get()).getCellByIndex(1).setStringValue(date);
                 } else {

--- a/src/main/java/gov/cabinetoffice/gap/testdata/TestData.java
+++ b/src/main/java/gov/cabinetoffice/gap/testdata/TestData.java
@@ -431,7 +431,7 @@ public class TestData {
 
     public static final SubmissionSection CUSTOM_SECTION_SUBMISSION = SubmissionSection
             .builder()
-            .sectionId("CUSTOM")
+            .sectionId("ce43cfe5-53d1-4a69-8a0a-6fce142f87d5")
             .sectionTitle("Custom section")
             .sectionStatus(SubmissionSectionStatus.COMPLETED)
             .questions(List.of(OPTIONAL_YES_NO_QUESTION, OPTIONAL_DATE_QUESTION, OPTIONAL_MULTISELECT_QUESTION, OPTIONAL_FILE_UPLOAD_QUESTION))
@@ -527,6 +527,7 @@ public class TestData {
             .legalName("Test Org Name v2")
             .schemeName("v2Scheme Name")
             .gapId("GAP-LL-20220927-00001")
+            .email("anexamplemail@gov.uk")
             .submittedDate(Instant.parse("2022-02-15T18:35:24.00Z"))
             .sections(V2_SUBMISSION_SECTIONS_LIST_LIMITED_WITH_CC_AND_CH)
             .schemeVersion(2)

--- a/src/test/java/gov/cabinetoffice/gap/service/OdtServiceTest.java
+++ b/src/test/java/gov/cabinetoffice/gap/service/OdtServiceTest.java
@@ -1,7 +1,5 @@
 package gov.cabinetoffice.gap.service;
 
-import gov.cabinetoffice.gap.model.Submission;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.odftoolkit.odfdom.doc.OdfDocument;
 import org.w3c.dom.Document;
@@ -17,23 +15,16 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 
 class OdtServiceTest {
-    private OdtService odtService;
-
-
-    @BeforeEach
-    void setUp() {
-        odtService = new OdtService();
-    }
 
     @Test
     void compareTestGenerateSingleOdtForSchemeVersion1() throws Exception {
-        final Submission submission = V1_SUBMISSION;
-        OdtService.generateSingleOdt(submission, "testFileName");
-        final OdfDocument generatedDoc = OdfDocument.loadDocument("/tmp/testFileName.odt");
-        final String generatedContent = docToString(generatedDoc.getContentDom());
+        OdtService.generateSingleOdt(V1_SUBMISSION, "testFileName");
+        final String generatedContent;
+        try (OdfDocument generatedDoc = OdfDocument.loadDocument("/tmp/testFileName.odt")) {
+            generatedContent = docToString(generatedDoc.getContentDom());
+        }
 
         assertThat(generatedContent).contains("Eligibility");
-        assertThat(generatedContent).contains("Required checks");
         assertThat(generatedContent).contains("V1_Company name");
         assertThat(generatedContent).contains("V1_9-10 St Andrew Square");
         assertThat(generatedContent).contains("V1_Edinburgh");
@@ -55,15 +46,14 @@ class OdtServiceTest {
 
     @Test
     void compareTestGenerateSingleOdtForLimitedCompanyWithCCAndCHForSchemeVersion2() throws Exception {
-        final Submission submission = V2_SUBMISSION_LIMITED_COMPANY_WITH_CC_AND_CH;
-        OdtService.generateSingleOdt(submission, "testFileName2");
-        final OdfDocument generatedDoc = OdfDocument.loadDocument("/tmp/testFileName2.odt");
-        final String generatedContent = docToString(generatedDoc.getContentDom());
+        OdtService.generateSingleOdt(V2_SUBMISSION_LIMITED_COMPANY_WITH_CC_AND_CH, "testFileName2");
+        final String generatedContent;
+        try (OdfDocument generatedDoc = OdfDocument.loadDocument("/tmp/testFileName2.odt")) {
+            generatedContent = docToString(generatedDoc.getContentDom());
+        }
 
         assertThat(generatedContent).contains("Test Org Name v2");
         assertThat(generatedContent).contains("Eligibility");
-        assertThat(generatedContent).contains("Required checks");
-        assertThat(generatedContent).contains("Legal name of organisation");
         assertThat(generatedContent).contains("V2_Company name");
         assertThat(generatedContent).contains("V2_9-10 St Andrew Square");
         assertThat(generatedContent).contains("V2_Edinburgh");
@@ -86,15 +76,14 @@ class OdtServiceTest {
 
     @Test
     void compareTestGenerateSingleOdtForLimitedCompanyWithoutCCAndCHForSchemeVersion2() throws Exception {
-        final Submission submission = V2_SUBMISSION_LIMITED_COMPANY_WITHOUT_CC_AND_CH;
-        OdtService.generateSingleOdt(submission, "testFileName3");
-        final OdfDocument generatedDoc = OdfDocument.loadDocument("/tmp/testFileName3.odt");
-        final String generatedContent = docToString(generatedDoc.getContentDom());
+        OdtService.generateSingleOdt(V2_SUBMISSION_LIMITED_COMPANY_WITHOUT_CC_AND_CH, "testFileName3");
+        final String generatedContent;
+        try (OdfDocument generatedDoc = OdfDocument.loadDocument("/tmp/testFileName3.odt")) {
+            generatedContent = docToString(generatedDoc.getContentDom());
+        }
 
-        assertThat(generatedContent).contains("Organisation name: Test Org Name v2");
+        assertThat(generatedContent).contains("Test Org Name v2");
         assertThat(generatedContent).contains("Eligibility");
-        assertThat(generatedContent).contains("Required checks");
-        assertThat(generatedContent).contains("Legal name of organisation");
         assertThat(generatedContent).contains("V2_Company name");
         assertThat(generatedContent).contains("V2_9-10 St Andrew Square");
         assertThat(generatedContent).contains("V2_Edinburgh");
@@ -117,15 +106,14 @@ class OdtServiceTest {
 
     @Test
     void compareTestGenerateSingleOdtForNonLimitedCompanyForSchemeVersion2() throws Exception {
-        final Submission submission = V2_SUBMISSION_NON_LIMITED_COMPANY;
-        OdtService.generateSingleOdt(submission, "testFileName4");
-        final OdfDocument generatedDoc = OdfDocument.loadDocument("/tmp/testFileName4.odt");
-        final String generatedContent = docToString(generatedDoc.getContentDom());
+        OdtService.generateSingleOdt(V2_SUBMISSION_NON_LIMITED_COMPANY, "testFileName4");
+        final String generatedContent;
+        try (OdfDocument generatedDoc = OdfDocument.loadDocument("/tmp/testFileName4.odt")) {
+            generatedContent = docToString(generatedDoc.getContentDom());
+        }
 
-        assertThat(generatedContent).contains("Organisation name: Test Non Limited Company v2");
+        assertThat(generatedContent).contains("Test Non Limited Company v2");
         assertThat(generatedContent).contains("Eligibility");
-        assertThat(generatedContent).contains("Required checks");
-        assertThat(generatedContent).contains("Legal name of organisation");
         assertThat(generatedContent).contains("V2_Company name");
         assertThat(generatedContent).contains("V2_9-10 St Andrew Square");
         assertThat(generatedContent).contains("V2_Edinburgh");
@@ -148,14 +136,14 @@ class OdtServiceTest {
 
     @Test
     void compareTestGenerateSingleOdtForIndividualForSchemeVersion2() throws Exception {
-        final Submission submission = V2_SUBMISSION_INDIVIDUAL;
-        OdtService.generateSingleOdt(submission, "testFileName5");
-        final OdfDocument generatedDoc = OdfDocument.loadDocument("/tmp/testFileName5.odt");
-        final String generatedContent = docToString(generatedDoc.getContentDom());
+        OdtService.generateSingleOdt(V2_SUBMISSION_INDIVIDUAL, "testFileName5");
+        final String generatedContent;
+        try (OdfDocument generatedDoc = OdfDocument.loadDocument("/tmp/testFileName5.odt")) {
+            generatedContent = docToString(generatedDoc.getContentDom());
+        }
 
-        assertThat(generatedContent).contains("Applicant name: Test Individual v2");
+        assertThat(generatedContent).contains("Test Individual v2");
         assertThat(generatedContent).contains("Eligibility");
-        assertThat(generatedContent).contains("Required checks");
         assertThat(generatedContent).contains("Applicant name");
         assertThat(generatedContent).contains("V2_Company name");
         assertThat(generatedContent).contains("V2_9-10 St Andrew Square");
@@ -179,10 +167,11 @@ class OdtServiceTest {
 
     @Test
     void compareTestGenerateSingleOdtForOptionalCustomSectionQuestions() throws Exception {
-        final Submission submission = V2_SUBMISSION_WITH_CUSTOM_SECTION;
-        OdtService.generateSingleOdt(submission, "testFileName6");
-        final OdfDocument generatedDoc = OdfDocument.loadDocument("/tmp/testFileName6.odt");
-        final String generatedContent = docToString(generatedDoc.getContentDom());
+        OdtService.generateSingleOdt(V2_SUBMISSION_WITH_CUSTOM_SECTION, "testFileName6");
+        final String generatedContent;
+        try (OdfDocument generatedDoc = OdfDocument.loadDocument("/tmp/testFileName6.odt")) {
+            generatedContent = docToString(generatedDoc.getContentDom());
+        }
 
         assertThat(generatedContent).contains("Custom section");
         assertThat(generatedContent).contains("Yes/No question");

--- a/src/test/java/gov/cabinetoffice/gap/service/OdtServiceTest.java
+++ b/src/test/java/gov/cabinetoffice/gap/service/OdtServiceTest.java
@@ -60,7 +60,7 @@ class OdtServiceTest {
         final OdfDocument generatedDoc = OdfDocument.loadDocument("/tmp/testFileName2.odt");
         final String generatedContent = docToString(generatedDoc.getContentDom());
 
-        assertThat(generatedContent).contains("Organisation name: Test Org Name v2");
+        assertThat(generatedContent).contains("Test Org Name v2");
         assertThat(generatedContent).contains("Eligibility");
         assertThat(generatedContent).contains("Required checks");
         assertThat(generatedContent).contains("Legal name of organisation");


### PR DESCRIPTION
Back-ports [a recent feature push to find-applicant-backend](https://github.com/cabinetoffice/gap-find-applicant-backend/pull/95) to include the updated structure in ODT documents for the Admins when exporting submissions.

PR includes various fixes to remove warnings on the ODT Generator and it's tests.

PR Also aims to bump the Java version of the project from 11 to 17 LTS. Relevant pom, dockerfile and github actions files have been updated to reflect this.