### PR TITLE
TMI2-606: Export failure email

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -18,6 +18,11 @@
         </dependency>
         <dependency>
             <groupId>com.amazonaws</groupId>
+            <artifactId>aws-java-sdk-sns</artifactId>
+            <version>1.12.593</version>
+        </dependency>
+        <dependency>
+            <groupId>com.amazonaws</groupId>
             <artifactId>aws-lambda-java-core</artifactId>
             <version>1.2.1</version>
         </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -200,6 +200,7 @@
                         <ADMIN_API_SECRET>test-api-secret</ADMIN_API_SECRET>
                         <USER_POOL_ID>testUserPoolId</USER_POOL_ID>
                         <PUBLIC_KEY>MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA1Cg0wsx+v3KKqn9sveTVifxX60m09u96wq00/Ip/gg3g2h5pvpB0sDooC+aOVXIuJGO9f6aiwEqfT8Jkm21rs05ytIa99GmbGBC1a9Tb+JROiK0FG8tqQ2ol3Xfz6ygXlxm83eSTZmpmKi5/AfY5d0n7XXuuqRoYpmkq9jEyxnxN9maCvFQN5gBxlEbfc1mdwfe3for5E/1E7uuFc3M7MqyH/UbZZdMayJItNDU6F7eYF99mD8xh19WWLU9mhlaX2UqYJ8DriWTkSHqRPGgeY7Kr8tuIBgYutJ2BUl1tZsVUSe1R2aDiz5Il9vAS3sbJeAiGE7wFMCYRBst0MTk1kQIDAQAB</PUBLIC_KEY>
+                        <TOPIC_ARN>arn:partition:service:region:account-id:resource-id</TOPIC_ARN>
                     </environmentVariables>
                 </configuration>
             </plugin>

--- a/src/main/java/gov/cabinetoffice/gap/lambda/Handler.java
+++ b/src/main/java/gov/cabinetoffice/gap/lambda/Handler.java
@@ -98,6 +98,7 @@ public class Handler implements RequestHandler<SQSEvent, SQSBatchResponse> {
             } else {
                 logger.info(
                         String.format("Outstanding exports for export batch %s: %s", exportBatchId, outstandingCount));
+                SnsService.failureInExport(submission.getSchemeName(), outstandingCount);
             }
 
             // STEP 9 - clear tmp dir as this is preserved between frequent invocations

--- a/src/main/java/gov/cabinetoffice/gap/lambda/Handler.java
+++ b/src/main/java/gov/cabinetoffice/gap/lambda/Handler.java
@@ -81,7 +81,6 @@ public class Handler implements RequestHandler<SQSEvent, SQSBatchResponse> {
             if (Objects.equals(outstandingCount, 0L)) {
                 ZipService.deleteTmpDirContents();
                 logger.info("Tmp dir cleared before super zip");
-                // TODO should we add status for processing etc?
                 try {
                     logger.info("Fetching completedGrantExports to create super zip with exportBatchId: " + exportBatchId );
                     final GrantExportListDTO completedGrantExports = ExportRecordService.getCompletedExportRecordsByBatchId(restClient, exportBatchId);
@@ -90,7 +89,7 @@ public class Handler implements RequestHandler<SQSEvent, SQSBatchResponse> {
                     ZipService.createSuperZip(completedGrantExports.getGrantExports());
                     logger.info("Super zip complete");
 
-                    final String superZipFilename = HelperUtils.generateFilename(submission.getSchemeName(), ""); // TODO what should we name this
+                    final String superZipFilename = HelperUtils.generateFilename(submission.getSchemeName(), "");
 
                     logger.info("Starting to upload super zip to s3");
                     String superZipObjectKey = ZipService.uploadZip(submission.getSchemeId(), superZipFilename);

--- a/src/main/java/gov/cabinetoffice/gap/model/FailedExportCountDTO.java
+++ b/src/main/java/gov/cabinetoffice/gap/model/FailedExportCountDTO.java
@@ -1,0 +1,12 @@
+package gov.cabinetoffice.gap.model;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+@Data
+@AllArgsConstructor
+public class FailedExportCountDTO {
+
+    private Long failedCount;
+
+}

--- a/src/main/java/gov/cabinetoffice/gap/service/ExportRecordService.java
+++ b/src/main/java/gov/cabinetoffice/gap/service/ExportRecordService.java
@@ -3,6 +3,7 @@ package gov.cabinetoffice.gap.service;
 import gov.cabinetoffice.gap.enums.GrantExportStatus;
 import gov.cabinetoffice.gap.lambda.Handler;
 import gov.cabinetoffice.gap.model.AddingS3ObjectKeyDTO;
+import gov.cabinetoffice.gap.model.FailedExportCountDTO;
 import gov.cabinetoffice.gap.model.GrantExportListDTO;
 import gov.cabinetoffice.gap.model.OutstandingExportCountDTO;
 import okhttp3.OkHttpClient;
@@ -39,6 +40,12 @@ public class ExportRecordService {
         logger.info("Sending getRequest to {}", getEndpoint);
 
         return  RestService.sendGetRequest(restClient, null, getEndpoint, GrantExportListDTO.class);
+    }
+
+    public static long getFailedExportsCount(OkHttpClient restClient, String exportId) throws Exception {
+        final String getEndpoint = "/export-batch/" + exportId + "/failedCount";
+
+        return RestService.sendGetRequest(restClient, null, getEndpoint, FailedExportCountDTO.class).getFailedCount();
     }
 
 }

--- a/src/main/java/gov/cabinetoffice/gap/service/ExportRecordService.java
+++ b/src/main/java/gov/cabinetoffice/gap/service/ExportRecordService.java
@@ -48,4 +48,9 @@ public class ExportRecordService {
         return RestService.sendGetRequest(restClient, null, getEndpoint, FailedExportCountDTO.class).getFailedCount();
     }
 
+    public static long getRemainingExportsCount(OkHttpClient restClient, String exportId) throws Exception {
+        final String getEndpoint = "/export-batch/" + exportId + "/remainingCount";
+        return RestService.sendGetRequest(restClient, null, getEndpoint, OutstandingExportCountDTO.class).getOutstandingCount();
+    }
+
 }

--- a/src/main/java/gov/cabinetoffice/gap/service/GrantExportBatchService.java
+++ b/src/main/java/gov/cabinetoffice/gap/service/GrantExportBatchService.java
@@ -17,7 +17,7 @@ public class GrantExportBatchService {
         final String patchEndpoint = "/grant-export-batch/" + exportId + "/status";
         try{
             logger.info("Sending patch request to {} to update status to: {}", patchEndpoint, newStatus.toString());
-            RestService.sendPatchRequest(restClient, "\"" + newStatus.toString() + "\"", patchEndpoint);
+            RestService.sendPatchRequest(restClient, newStatus, patchEndpoint);
         }
         catch (Exception e) {
             logger.error("Unable to send patch request to update status to {} with error message {}", newStatus.toString(), e);

--- a/src/main/java/gov/cabinetoffice/gap/service/SnsService.java
+++ b/src/main/java/gov/cabinetoffice/gap/service/SnsService.java
@@ -1,0 +1,40 @@
+package gov.cabinetoffice.gap.service;
+
+import com.amazonaws.services.sns.AmazonSNSClient;
+import com.amazonaws.services.sns.AmazonSNSClientBuilder;
+import com.amazonaws.services.sns.model.AmazonSNSException;
+import com.amazonaws.services.sns.model.PublishRequest;
+import com.amazonaws.services.sns.model.PublishResult;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.log4j.Log4j2;
+
+@RequiredArgsConstructor
+@Log4j2
+public class SnsService {
+
+    private static String publishMessageToTopic(String subject, String body) {
+        try {
+            AmazonSNSClient snsClient = (AmazonSNSClient) AmazonSNSClientBuilder.defaultClient();
+
+            //TODO: How do we store config for this lambda
+            final PublishRequest request = new PublishRequest(System.getenv("PLACEHOLDER_TOPIC_ARN"), body, subject);
+            final PublishResult result = snsClient.publish(request);
+
+            log.info("Message published to SNS topic");
+
+            return "Message with message id:" + result.getMessageId() + " sent.";
+        } catch (AmazonSNSException e) {
+            return "Error publishing message to SNS topic with error: " + e.getErrorMessage();
+        }
+
+    }
+
+    public static String failureInExport(String grantName, long failureCount) {
+        //TODO: This copy is subject to change
+        final String subject = "Application download run failed";
+        final String body = String.format("An application download run for %s has encountered errors. This has caused %s applications to become unavailable to download.", grantName, failureCount);
+
+        return publishMessageToTopic(subject, body);
+    }
+
+}

--- a/src/main/java/gov/cabinetoffice/gap/service/SnsService.java
+++ b/src/main/java/gov/cabinetoffice/gap/service/SnsService.java
@@ -1,7 +1,6 @@
 package gov.cabinetoffice.gap.service;
 
 import com.amazonaws.services.sns.AmazonSNSClient;
-import com.amazonaws.services.sns.AmazonSNSClientBuilder;
 import com.amazonaws.services.sns.model.AmazonSNSException;
 import com.amazonaws.services.sns.model.PublishRequest;
 import com.amazonaws.services.sns.model.PublishResult;
@@ -12,12 +11,15 @@ import lombok.extern.log4j.Log4j2;
 @Log4j2
 public class SnsService {
 
-    private static String publishMessageToTopic(String subject, String body) {
-        try {
-            AmazonSNSClient snsClient = (AmazonSNSClient) AmazonSNSClientBuilder.defaultClient();
+    AmazonSNSClient snsClient;
 
-            //TODO: How do we store config for this lambda
-            final PublishRequest request = new PublishRequest(System.getenv("PLACEHOLDER_TOPIC_ARN"), body, subject);
+    public SnsService (AmazonSNSClient snsClient) {
+        this.snsClient = snsClient;
+    }
+
+    private String publishMessageToTopic(String subject, String body) {
+        try {
+            final PublishRequest request = new PublishRequest(System.getenv("TOPIC_ARN"), body, subject);
             final PublishResult result = snsClient.publish(request);
 
             log.info("Message published to SNS topic");
@@ -29,9 +31,9 @@ public class SnsService {
 
     }
 
-    public static String failureInExport(String grantName, long failureCount) {
+    public String failureInExport(String grantName, long failureCount) {
         //TODO: This copy is subject to change
-        final String subject = "Application download run failed";
+        final String subject = String.format("%s - Application download run errors", grantName);
         final String body = String.format("An application download run for %s has encountered errors. This has caused %s applications to become unavailable to download.", grantName, failureCount);
 
         return publishMessageToTopic(subject, body);

--- a/src/test/java/gov/cabinetoffice/gap/lambda/HandlerTest.java
+++ b/src/test/java/gov/cabinetoffice/gap/lambda/HandlerTest.java
@@ -251,6 +251,7 @@ public class HandlerTest {
         }
     }
 
+    // TODO: This needs reworked to fit SnsService
     @Test
     void ShouldSendOutstandingErrorsEmailIfThereAreStillOutstandingExportErrors() {
         final SQSEvent event = EventLoader.loadSQSEvent("testEvent.json");

--- a/src/test/java/gov/cabinetoffice/gap/service/SnsServiceTest.java
+++ b/src/test/java/gov/cabinetoffice/gap/service/SnsServiceTest.java
@@ -1,0 +1,49 @@
+package gov.cabinetoffice.gap.service;
+
+import com.amazonaws.services.sns.AmazonSNSClient;
+import com.amazonaws.services.sns.model.AmazonSNSException;
+import com.amazonaws.services.sns.model.PublishRequest;
+import com.amazonaws.services.sns.model.PublishResult;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
+
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+
+
+public class SnsServiceTest {
+    private final AmazonSNSClient snsClient = Mockito.mock(AmazonSNSClient.class);
+
+    private final SnsService snsService = new SnsService(snsClient);
+
+    private final String grantName = "Grant";
+
+    private final long applicationCount = 100;
+
+    @BeforeEach
+    void beforeAll() throws Exception {
+        reset(snsClient);
+    }
+
+    @Test
+    void successfullyPublishesMessage() {
+        final PublishResult mockResult = new PublishResult().withMessageId("mockMessageId");
+        when(snsClient.publish(any(PublishRequest.class))).thenReturn(mockResult);
+
+        final String result = snsService.failureInExport(grantName, applicationCount);
+
+        assertThat(result).isEqualTo("Message with message id:mockMessageId sent.");
+    }
+
+    @Test
+    void throwsException() {
+        when(snsClient.publish(any())).thenThrow(new AmazonSNSException("error publishing message"));
+        final String result = snsService.failureInExport(grantName, applicationCount);
+        assertThat(result).isEqualTo("Error publishing message to SNS topic with error: error publishing message");
+    }
+}


### PR DESCRIPTION
https://technologyprogramme.atlassian.net/browse/TMI2-606

Adds AWS Simple Notification Service to the lambda, allowing it to send emails in the event there are outstanding errors in the export. 

The current `getOutstandingExportCount` will only return a count for any grant not with COMPLETED status. So a new endpoint was added to count how many grants still need to be processed for the batch.On the last submission export for that batch, another endpoint is called to get the number of failed exports in that batch and sends the support email with that count. 