### PR TITLE
TMI2-669: download attachments error path

### DIFF
--- a/src/main/java/gov/cabinetoffice/gap/service/ExportRecordService.java
+++ b/src/main/java/gov/cabinetoffice/gap/service/ExportRecordService.java
@@ -11,26 +11,27 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public class ExportRecordService {
+
     private static final Logger logger = LoggerFactory.getLogger(Handler.class);
 
     public static void updateExportRecordStatus(OkHttpClient restClient, String exportId, String submissionId, GrantExportStatus newStatus)
             throws Exception {
 
         final String postEndpoint = "/submissions/" + submissionId + "/export-batch/" + exportId + "/status";
-
+        logger.info("Sending postRequest to {}", postEndpoint);
         RestService.sendPostRequest(restClient, "\"" + newStatus.toString() + "\"", postEndpoint);
     }
 
     public static long getOutstandingExportsCount(OkHttpClient restClient, String exportId) throws Exception {
         final String getEndpoint = "/grant-export/" + exportId + "/outstandingCount";
-
+        logger.info("Sending getRequest to {}", getEndpoint);
         return RestService.sendGetRequest(restClient, null, getEndpoint, OutstandingExportCountDTO.class).getOutstandingCount();
     }
 
     public static void addS3ObjectKeyToExportRecord(OkHttpClient restClient, String exportId, String submissionId, String s3ObjectKey)
             throws Exception {
         final String patchEndpoint = "/submissions/" + submissionId + "/export-batch/" + exportId + "/s3-object-key";
-
+        logger.info("Sending patchRequest to {}", patchEndpoint);
         RestService.sendPatchRequest(restClient, new AddingS3ObjectKeyDTO(s3ObjectKey), patchEndpoint);
     }
 

--- a/src/main/java/gov/cabinetoffice/gap/service/SubmissionService.java
+++ b/src/main/java/gov/cabinetoffice/gap/service/SubmissionService.java
@@ -7,10 +7,14 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import gov.cabinetoffice.gap.model.Submission;
 import gov.cabinetoffice.gap.model.SubmissionSection;
 import okhttp3.OkHttpClient;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.List;
 
 public class SubmissionService {
+
+    private static final Logger logger = LoggerFactory.getLogger(SubmissionService.class);
 
     public static void addSubmissionSectionsJsonToSubmissionModel(Submission submissionModel,
             String submissionSectionsJson) throws JsonMappingException, JsonProcessingException {
@@ -24,9 +28,8 @@ public class SubmissionService {
     }
 
     public static Submission getSubmissionData(OkHttpClient restClient, String batchId, String submissionId) throws Exception {
-
         String getEndpoint = "/submissions/" + submissionId + "/export-batch/" + batchId + "/submission";
-
+        logger.info("Sending getRequest to {}", getEndpoint);
         return RestService.sendGetRequest(restClient, null, getEndpoint, Submission.class);
     }
 }


### PR DESCRIPTION
https://technologyprogramme.atlassian.net/browse/TMI2-669

when an individual grant submission export fails, it creates a zip with just the attachments for that submission, if any. For any failed attachment downloads, it creates a text file and adds the names these to the text file which is then added to the zip. The attachment zip file is then uploaded to s3 and the grant_export location is updated