### PR TITLE
TMI2-601: Email admin when Export finishes

### DIFF
--- a/src/main/java/gov/cabinetoffice/gap/lambda/Handler.java
+++ b/src/main/java/gov/cabinetoffice/gap/lambda/Handler.java
@@ -101,11 +101,12 @@ public class Handler implements RequestHandler<SQSEvent, SQSBatchResponse> {
 
                     ExportRecordService.addS3ObjectKeyToGrantExportBatchRecord(restClient, exportBatchId, superZipObjectKey);
                     ExportRecordService.updateGrantExportBatchRecordStatus(restClient, exportBatchId, GrantExportStatus.COMPLETE);
-                    NotifyService.sendConfirmationEmail(restClient, emailAddress, exportBatchId, submission.getSchemeId(),
-                            submissionId);
                 } catch (Exception e) {
                     logger.error("Could not process message while trying to create super zip", e);
                     ExportRecordService.updateGrantExportBatchRecordStatus(restClient, exportBatchId, GrantExportStatus.FAILED);
+                } finally {
+                    NotifyService.sendConfirmationEmail(restClient, emailAddress, exportBatchId, submission.getSchemeId(),
+                            submissionId);
                 }
 
             } else {


### PR DESCRIPTION
Moved the admin email notification to a finally() block so it always runs after the super zip attempt
Refactored tests to account for sending the email