### PR TITLE
TMI2-669: handle failed exports with no attachments

### DIFF
--- a/src/main/java/gov/cabinetoffice/gap/lambda/Handler.java
+++ b/src/main/java/gov/cabinetoffice/gap/lambda/Handler.java
@@ -123,6 +123,8 @@ public class Handler implements RequestHandler<SQSEvent, SQSBatchResponse> {
             ExportRecordService.updateExportRecordStatus(restClient, exportBatchId, submissionId, GrantExportStatus.FAILED);
 
             try {
+                logger.info("Trying to create attachment zip");
+
                 if(submission !=null && submission.isHasAttachments()) {
                     logger.info("Creating attachments zip for failed submission with ID {}", submissionId);
                     // download all relevant attachments and zip without the .odt
@@ -130,6 +132,7 @@ public class Handler implements RequestHandler<SQSEvent, SQSBatchResponse> {
                     final String zipObjectKey = ZipService.uploadZip(gapId, ATTACHMENTS_ZIP_FILE_NAME);
                     ExportRecordService.addS3ObjectKeyToExportRecord(restClient, exportBatchId, submissionId, zipObjectKey);
                 } else if(submission !=null) {
+                    logger.info("Updating location to null for submission {}", submissionId);
                     ExportRecordService.addS3ObjectKeyToExportRecord(restClient, exportBatchId, submissionId, null);
                 }
             }

--- a/src/main/java/gov/cabinetoffice/gap/lambda/Handler.java
+++ b/src/main/java/gov/cabinetoffice/gap/lambda/Handler.java
@@ -45,6 +45,7 @@ public class Handler implements RequestHandler<SQSEvent, SQSBatchResponse> {
         String schemeName = "";
         String filename = "";
         String gapId = "";
+        Submission submission = null;
 
         try {
             logger.info("Received message with submissionId: {} and exportBatchId: {}", submissionId, exportBatchId);
@@ -54,7 +55,7 @@ public class Handler implements RequestHandler<SQSEvent, SQSBatchResponse> {
 
             // STEP 1 - get submission from database
             // legal name is assigned from the response they give in the essential questions section
-            final Submission submission = SubmissionService.getSubmissionData(restClient, exportBatchId, submissionId);
+            submission = SubmissionService.getSubmissionData(restClient, exportBatchId, submissionId);
             String legalName = submission.getSchemeVersion() == 1 ?
                     submission.getSectionById("ESSENTIAL").getQuestionById("APPLICANT_ORG_NAME").getResponse()
                     :
@@ -122,11 +123,15 @@ public class Handler implements RequestHandler<SQSEvent, SQSBatchResponse> {
             ExportRecordService.updateExportRecordStatus(restClient, exportBatchId, submissionId, GrantExportStatus.FAILED);
 
             try {
-                logger.info("Creating attachments zip for failed submission with ID {}", submissionId);
-                // download all relevant attachments and zip without the .odt
-                ZipService.createZip(s3client, filename, applicationId, submissionId, false);
-                final String zipObjectKey = ZipService.uploadZip(gapId, ATTACHMENTS_ZIP_FILE_NAME);
-                ExportRecordService.addS3ObjectKeyToExportRecord(restClient, exportBatchId, submissionId, zipObjectKey);
+                if(submission !=null && submission.isHasAttachments()) {
+                    logger.info("Creating attachments zip for failed submission with ID {}", submissionId);
+                    // download all relevant attachments and zip without the .odt
+                    ZipService.createZip(s3client, filename, applicationId, submissionId, false);
+                    final String zipObjectKey = ZipService.uploadZip(gapId, ATTACHMENTS_ZIP_FILE_NAME);
+                    ExportRecordService.addS3ObjectKeyToExportRecord(restClient, exportBatchId, submissionId, zipObjectKey);
+                } else if(submission !=null) {
+                    ExportRecordService.addS3ObjectKeyToExportRecord(restClient, exportBatchId, submissionId, null);
+                }
             }
             catch (Exception error) {
                 logger.error("Couldn't create attachments zip for submission with ID " + submissionId,  error);

--- a/src/main/java/gov/cabinetoffice/gap/model/Submission.java
+++ b/src/main/java/gov/cabinetoffice/gap/model/Submission.java
@@ -25,6 +25,7 @@ public class Submission {
     private List<SubmissionSection> sections;
     private String email;
     private Integer schemeVersion;
+    private boolean hasAttachments;
 
     public SubmissionSection getSectionById(String sectionId) {
         return this.sections

--- a/src/test/java/gov/cabinetoffice/gap/testData/SubmissionTestData.java
+++ b/src/test/java/gov/cabinetoffice/gap/testData/SubmissionTestData.java
@@ -24,7 +24,7 @@ public class SubmissionTestData {
     public static final String EMAIL = "testEmailAddress";
 
     public static final Submission V1_SUBMISSION_WITHOUT_SECTIONS = new Submission(SCHEME_ID, SCHEME_NAME, LEGAL_NAME,
-            GAP_ID, SUBMITTED_DATE, null, EMAIL, 1);
+            GAP_ID, SUBMITTED_DATE, null, EMAIL, 1, true);
 
     public static final String SUBMISSION_SINGLE_EMPTY_SECTION_ARRAY_JSON_STRING = """
             [    {
@@ -56,6 +56,6 @@ public class SubmissionTestData {
                             .response("test org name").build())));
 
     public static final Submission V1_SUBMISSION_WITH_ESSENTIAL_SECTION = new Submission(SCHEME_ID, SCHEME_NAME,
-            LEGAL_NAME, GAP_ID, SUBMITTED_DATE, ESSENTIAL_INFO_SECTION, EMAIL, 1);
+            LEGAL_NAME, GAP_ID, SUBMITTED_DATE, ESSENTIAL_INFO_SECTION, EMAIL, 1, true);
 
 }


### PR DESCRIPTION
Checks if a failed submission export has attachments, if it doesn't, it doesn't create the attachments zip and it clears the location field in the table

https://technologyprogramme.atlassian.net/browse/TMI2-669